### PR TITLE
Mark omni-socat executable

### DIFF
--- a/hack/rocky-bash.setup.sh
+++ b/hack/rocky-bash.setup.sh
@@ -7,6 +7,7 @@ __get_omnisocat () {
       -sLo omni-socat.zip
   sudo dnf -y install unzip
   unzip -o omni-socat.zip -d $(dirname $OMNISOCATCMD)
+  chmod +x $OMNISOCATCMD
   rm omni-socat.zip
 }
 

--- a/hack/ubuntu-bash.setup.sh
+++ b/hack/ubuntu-bash.setup.sh
@@ -7,6 +7,7 @@ __get_omnisocat () {
   curl https://github.com/masahide/OmniSSHAgent/releases/latest/download/omni-socat.zip \
       -sLo omni-socat.zip
   unzip -o omni-socat.zip -d $(dirname $OMNISOCATCMD)
+  chmod +x $OMNISOCATCMD
   rm omni-socat.zip
 }
 

--- a/hack/ubuntu-fish.setup.fish
+++ b/hack/ubuntu-fish.setup.fish
@@ -6,6 +6,7 @@ function __get_omnisocat
   curl https://github.com/masahide/OmniSSHAgent/releases/latest/download/omni-socat.zip \
       -sLo omni-socat.zip
   unzip -o omni-socat.zip -d (dirname $OMNISOCATCMD)
+  chmod +x $OMNISOCATCMD
   rm omni-socat.zip
 end
 


### PR DESCRIPTION
On a fresh install, I've just encountered the problem that [the auto-downloaded `omni-socat.exe` was not executable, giving errors from `ssh-add -l` in WSL2](https://github.com/masahide/OmniSSHAgent/issues/20#issuecomment-1140223953).

Sorry for the three commits that I'd normally do as one -- had to do this in the GitHub web UI. If you prefer to squash them before merging, very fine by me.

Thank you for OmniSSHAgent!