### PR TITLE
Improved socket check

### DIFF
--- a/hack/rocky-bash.setup.sh
+++ b/hack/rocky-bash.setup.sh
@@ -27,8 +27,8 @@ setup_omnisocat () {
   [[ -f /usr/sbin/ss ]] || __get_ss
   [[ -f /usr/bin/socat ]] || __get_socat
 
-  ss -a | grep -q $SSH_AUTH_SOCK
-  [[ $? -ne 0 ]]  || return
+  # Checks wether $SSH_AUTH_SOCK is a socket or not
+  [[ -S $SSH_AUTH_SOCK ]]  && return
 
   rm -f $SSH_AUTH_SOCK
   (setsid socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:"$OMNISOCATCMD",nofork &) >/dev/null 2>&1

--- a/hack/rocky-bash.setup.sh
+++ b/hack/rocky-bash.setup.sh
@@ -28,7 +28,8 @@ setup_omnisocat () {
   [[ -f /usr/bin/socat ]] || __get_socat
 
   # Checks wether $SSH_AUTH_SOCK is a socket or not
-  [[ -S $SSH_AUTH_SOCK ]]  && return
+  ss -a | grep -q $SSH_AUTH_SOCK
+  [[ -S $SSH_AUTH_SOCK && $? -eq 0 ]]  && return
 
   rm -f $SSH_AUTH_SOCK
   (setsid socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:"$OMNISOCATCMD",nofork &) >/dev/null 2>&1

--- a/hack/ubuntu-bash.setup.sh
+++ b/hack/ubuntu-bash.setup.sh
@@ -22,7 +22,8 @@ setup_omnisocat () {
   [[ -f /usr/bin/socat ]] || __get_socat
   
   # Checks wether $SSH_AUTH_SOCK is a socket or not
-  [[ -S $SSH_AUTH_SOCK ]]  && return
+    ss -a | grep -q $SSH_AUTH_SOCK
+  [[ -S $SSH_AUTH_SOCK && $? -eq 0 ]]  && return
 
   rm -f $SSH_AUTH_SOCK
   (setsid socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:"$OMNISOCATCMD",nofork &) >/dev/null 2>&1

--- a/hack/ubuntu-bash.setup.sh
+++ b/hack/ubuntu-bash.setup.sh
@@ -21,8 +21,8 @@ setup_omnisocat () {
   [[ -f $OMNISOCATCMD ]]  || __get_omnisocat
   [[ -f /usr/bin/socat ]] || __get_socat
   
-  ss -a | grep -q $SSH_AUTH_SOCK
-  [[ $? -ne 0 ]]  || return
+  # Checks wether $SSH_AUTH_SOCK is a socket or not
+  [[ -S $SSH_AUTH_SOCK ]]  && return
 
   rm -f $SSH_AUTH_SOCK
   (setsid socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:"$OMNISOCATCMD",nofork &) >/dev/null 2>&1

--- a/hack/ubuntu-fish.setup.fish
+++ b/hack/ubuntu-fish.setup.fish
@@ -24,8 +24,8 @@ function setup_omnisocat
     __get_socat
   end
   
-  ss -a | grep -q $SSH_AUTH_SOCK
-  if not test $status -ne 0
+  # Checks wether $SSH_AUTH_SOCK is a socket or not
+  if test -S $SSH_AUTH_SOCK
     return
   end
   

--- a/hack/ubuntu-fish.setup.fish
+++ b/hack/ubuntu-fish.setup.fish
@@ -25,7 +25,8 @@ function setup_omnisocat
   end
   
   # Checks wether $SSH_AUTH_SOCK is a socket or not
-  if test -S $SSH_AUTH_SOCK
+  ss -a | grep -q $SSH_AUTH_SOCK
+  if test -S $SSH_AUTH_SOCK -a $status -eq 0
     return
   end
   


### PR DESCRIPTION
I noticed that the `$SSH_AUTH_SOCKET` has an open socket without "file creation" which is causing it to appear in the `ss -a` list. To improve the check, I suggest using the -S flag of the test command (in fish) or conditional brackets in bash.