### PR TITLE
Fix Recurring Error in PacketWorker Processing

### DIFF
--- a/cmd/wsl2-ssh-agent-proxy/pwsh.ps1
+++ b/cmd/wsl2-ssh-agent-proxy/pwsh.ps1
@@ -75,7 +75,10 @@ $PacketWorkerScript = {
                     }
                     catch {
                         [Console]::Error.WriteLine("PacketWorker [ch:$($Packet.channelID) type:$($Packet.TypeNum)]: Exception occurred while processing. Error: $($_.Exception.Message). Worker will stop.")
+                        $this.NamedPipeStream.Close()
+                        $this.NamedPipeStream = $null
                         $this.StopWorker($Packet.ChannelID)
+                        Start-Sleep -Seconds 1.0
                         continue
                     }
                 }


### PR DESCRIPTION
Resolved an issue where the following error was repeatedly output:
"PacketWorker [ch:9 type:1]: Exception occurred while processing. Error..."

This fix addresses the root cause of the exception in the PacketWorker processing and ensures that the error message is no longer repeatedly output in the logs.
