### PR TITLE
Fix agent requests for SHA512 signatures

### DIFF
--- a/app.go
+++ b/app.go
@@ -124,12 +124,12 @@ func (a *App) startup(ctx context.Context) {
 		go na.RunAgent()
 	}
 	if a.settings.UnixSocketAgent {
-		ua := &unix.DomainSock{Agent: a.keyRing, Debug: debug, Path: a.settings.UnixSocketPath}
+		ua := &unix.DomainSock{ExtendedAgent: a.keyRing, Debug: debug, Path: a.settings.UnixSocketPath}
 		go ua.RunAgent()
 		log.Println("Start Unix domain socket agent..")
 	}
 	if a.settings.CygWinAgent {
-		ca := &cygwinsocket.CygwinSock{Agent: a.keyRing, Debug: debug, Path: a.settings.CygWinSocketPath}
+		ca := &cygwinsocket.CygwinSock{ExtendedAgent: a.keyRing, Debug: debug, Path: a.settings.CygWinSocketPath}
 		go ca.RunAgent()
 		log.Println("Starting Cygwin unix domain socket agent..")
 	}

--- a/pkg/cygwinsocket/cygwinsocket.go
+++ b/pkg/cygwinsocket/cygwinsocket.go
@@ -18,7 +18,7 @@ import (
 )
 
 type CygwinSock struct {
-	agent.Agent
+	agent.ExtendedAgent
 	Debug    bool
 	Path     string
 	listener net.Listener

--- a/pkg/unix/unix.go
+++ b/pkg/unix/unix.go
@@ -13,7 +13,7 @@ import (
 )
 
 type DomainSock struct {
-	agent.Agent
+	agent.ExtendedAgent
 	Debug bool
 	Path  string
 }


### PR DESCRIPTION
This fixes `ssh` agent errors from a new enough SSH which requests for SHA512 signatures without checking for it. Without this, I get:

```
agent key RSA SHA256:<snip>
returned incorrect signature type sign_and_send_pubkey: no mutual
signature supported
```

See https://github.com/openssh/openssh-portable/blob/6575859d7acb110acf408707f98ed9744ca7d692/sshconnect2.c#L1441