### PR TITLE
Add balloon notification settings and update versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 build/bin/
 wailsjs/
 hack/node_modules/
+omni-socat.zip
+build/windows/wails.exe.manifest
+cmd/agent-bench/agent-bench
+cmd/agent-bench/agent-bench.exe
+test*/
+pkg/muxconn
+pkg/stdioconn

--- a/app.go
+++ b/app.go
@@ -167,8 +167,14 @@ func (a *App) onSign(pubkey *agent.Key) error {
 		return errors.New("private key not found")
 	}
 
-	a.ti.ShowBalloonNotification(wintray.ID,
-		fmt.Sprintf("SSH Key '%s' was used", privkey.PublicKey.Comment))
+	name := privkey.PublicKey.Comment
+	if len(name) == 0 {
+		name = truncateString(privkey.PublicKey.SHA256)
+	}
+	msg := fmt.Sprintf("SSH Key '%s' was used", name)
+	if a.settings.ShowBalloon {
+		a.ti.ShowBalloonNotification(wintray.ID, msg)
+	}
 	return nil
 }
 
@@ -256,7 +262,15 @@ func (a *App) Save(s store.SaveData) error {
 	a.settings.SaveData.UnixSocketAgent = s.UnixSocketAgent
 	a.settings.SaveData.UnixSocketPath = s.UnixSocketPath
 	a.settings.SaveData.CygWinAgent = s.CygWinAgent
+	a.settings.SaveData.ShowBalloon = s.ShowBalloon
 	a.settings.SaveData.CygWinSocketPath = s.CygWinSocketPath
 	a.settings.SaveData.ProxyModeOfNamedPipe = s.ProxyModeOfNamedPipe
 	return a.settings.Save()
+}
+
+func truncateString(s string) string {
+	if len(s) <= 16 {
+		return s
+	}
+	return s[:16] + "..."
 }

--- a/build/windows/info.json
+++ b/build/windows/info.json
@@ -1,10 +1,10 @@
 {
 	"fixed": {
-		"file_version": "0.3.5"
+		"file_version": "0.5.0"
 	},
 	"info": {
 		"0000": {
-			"ProductVersion": "0.3.5",
+			"ProductVersion": "0.5.0",
 			"CompanyName": "OmniSSHAgent",
 			"FileDescription": "OmniSSHAgent",
 			"LegalCopyright": "Copyright.........",

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -33,6 +33,7 @@
     NamedPipeAgent: false,
     UnixSocketAgent: false,
     CygWinAgent: false,
+    ShowBalloon: false,
     UnixSocketPath: "",
     CygWinSocketPath: "",
     ProxyModeOfNamedPipe: false,
@@ -100,6 +101,19 @@
                 >{data.StartHidden
                   ? "Hide the window on launch"
                   : "Show window on launch"}</span
+              >
+            </FormField>
+          </div>
+          <div>
+            <FormField>
+              <Switch
+                bind:checked={data.ShowBalloon}
+                value="Show a balloon notification when an SSH key is used"
+              />
+              <span
+                >{data.ShowBalloon
+                  ? "Show a balloon notification when an SSH key is used"
+                  : "Do not show a balloon notification when an SSH key is used"}</span
               >
             </FormField>
           </div>

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -26,6 +26,7 @@ type SaveData struct {
 	NamedPipeAgent   bool
 	UnixSocketAgent  bool
 	CygWinAgent      bool
+	ShowBalloon      bool
 	UnixSocketPath   string
 	CygWinSocketPath string
 
@@ -46,6 +47,7 @@ func initSetting() SaveData {
 		NamedPipeAgent:   true,
 		UnixSocketAgent:  true,
 		CygWinAgent:      true,
+		ShowBalloon:      true,
 		UnixSocketPath:   filepath.Join(home, "OmniSSHAgent.sock"),
 		CygWinSocketPath: filepath.Join(home, "OmniSSHCygwin.sock"),
 


### PR DESCRIPTION
- Introduced a setting to enable/disable balloon notifications for SSH key usage in the settings UI.
- Updated the application version to 0.5.0 in the info.json file.
- Enhanced the notification message to truncate long key names for better readability.