### PR TITLE
Store WebView files on the local cache directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,8 +59,16 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
+	userCacheDir, err := os.UserCacheDir()
+	if err == nil {
+		userCacheDir = filepath.Join(userCacheDir, getExeName())
+	} else {
+		log.Printf("cannot set user cache dir for Web View: %v", err)
+		userCacheDir = ""
+	}
+
 	// Create application with options
-	err := wails.Run(&options.App{
+	err = wails.Run(&options.App{
 		Title:             AppName,
 		Width:             900,
 		Height:            900,
@@ -84,6 +92,7 @@ func main() {
 		},
 		// Windows platform specific options
 		Windows: &windows.Options{
+			WebviewUserDataPath:  userCacheDir,
 			WebviewIsTransparent: false,
 			WindowIsTranslucent:  false,
 			DisableWindowIcon:    false,


### PR DESCRIPTION
This allows users with their %APPDATA% on a network share to not have conflicts on the data store.

In my case, my %APPDATA% is on a UNC path and when both my computers are on, the webview instance crashes from time to time.