### PR TITLE
Ensure tray registration fails fast with alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ cmd/agent-bench/agent-bench.exe
 test*/
 pkg/muxconn
 pkg/stdioconn
+node_modules/
+frontend/node_modules/

--- a/app.go
+++ b/app.go
@@ -25,14 +25,16 @@ import (
 
 // App application struct
 type App struct {
-	ctx          context.Context
-	agentCtx     context.Context
-	ti           *wintray.TrayIcon
-	keyRing      *sshutil.KeyRing
-	settings     *store.Settings
-	wg           sync.WaitGroup
-	cancelAgents context.CancelFunc
-	shutdownOnce sync.Once
+	ctx              context.Context
+	agentCtx         context.Context
+	ti               *wintray.TrayIcon
+	keyRing          *sshutil.KeyRing
+	settings         *store.Settings
+	wg               sync.WaitGroup
+	cancelAgents     context.CancelFunc
+	shutdownOnce     sync.Once
+	debugLogMenuItem *wintray.MenuItem
+	logDirMenuItem   *wintray.MenuItem
 }
 
 // NewApp creates a new App application struct
@@ -55,24 +57,16 @@ func (a *App) systrayOnReady() {
 	mQuit := a.ti.AddMenuItem("Quit", "Quit the whole app")
 	mLogCheckBox := a.ti.AddMenuItemCheckbox("Debug log", "Enable debug log file output", false)
 	mLogDirOpen := a.ti.AddMenuItem("Open log directory", "open log directory")
-	mLogDirOpen.Disable()
+	a.debugLogMenuItem = mLogCheckBox
+	a.logDirMenuItem = mLogDirOpen
+	a.applyDebugLogMenuState()
 	go func() {
 		for {
 			select {
 			case <-mShowWindow.ClickedCh:
 				a.showWindow()
 			case <-mLogCheckBox.ClickedCh:
-				if mLogCheckBox.Checked() {
-					mLogCheckBox.Uncheck()
-					log.Print("Disable debug log")
-					Logger.SetEnable(false)
-					mLogDirOpen.Disable()
-				} else {
-					mLogCheckBox.Check()
-					Logger.SetEnable(true)
-					log.Print("Enable debug log")
-					mLogDirOpen.Enable()
-				}
+				a.setDebugLogEnabled(!mLogCheckBox.Checked())
 			case <-mQuit.ClickedCh:
 				log.Print("Quit was clicked on the menu")
 				a.Quit()
@@ -94,6 +88,9 @@ func (a *App) systrayOnExit() {
 func (a *App) startup(ctx context.Context) {
 	// Perform your setup here
 	a.ctx = ctx
+	if a.settings != nil {
+		Logger.SetEnable(a.settings.SaveData.DebugLog)
+	}
 	a.ti = wintray.NewTrayIcon()
 	a.ti.BalloonClickFunc = a.showWindow
 	a.ti.TrayClickFunc = a.showWindow
@@ -249,6 +246,31 @@ func (a *App) shutdown(ctx context.Context) {
 	})
 }
 
+func (a *App) setDebugLogEnabled(enabled bool) {
+	Logger.SetEnable(enabled)
+	if a.settings != nil {
+		a.settings.SaveData.DebugLog = enabled
+	}
+	a.applyDebugLogMenuState()
+}
+
+func (a *App) applyDebugLogMenuState() {
+	if a.debugLogMenuItem == nil {
+		return
+	}
+	if Logger.GetEnable() {
+		a.debugLogMenuItem.Check()
+		if a.logDirMenuItem != nil {
+			a.logDirMenuItem.Enable()
+		}
+		return
+	}
+	a.debugLogMenuItem.Uncheck()
+	if a.logDirMenuItem != nil {
+		a.logDirMenuItem.Disable()
+	}
+}
+
 func (a *App) AddLocalFile(pk sshkey.PrivateKeyFile) error {
 	pk.Name = filepath.Base(pk.FilePath)
 	pk.StoreType = sshutil.LocalStore
@@ -294,6 +316,7 @@ func (a *App) GetSettings() store.SaveData {
 	return a.settings.SaveData
 }
 func (a *App) Save(s store.SaveData) error {
+	a.setDebugLogEnabled(s.DebugLog)
 	a.settings.SaveData.StartHidden = s.StartHidden
 	a.settings.SaveData.PageantAgent = s.PageantAgent
 	a.settings.SaveData.NamedPipeAgent = s.NamedPipeAgent

--- a/app.go
+++ b/app.go
@@ -32,6 +32,7 @@ type App struct {
 	settings     *store.Settings
 	wg           sync.WaitGroup
 	cancelAgents context.CancelFunc
+	shutdownOnce sync.Once
 }
 
 // NewApp creates a new App application struct
@@ -236,14 +237,16 @@ func (a *App) Quit() {
 
 // shutdown はruntime.Quitから呼ばれる
 func (a *App) shutdown(ctx context.Context) {
-	log.Print("shutdown")
-	if a.cancelAgents != nil {
-		a.cancelAgents()
-	}
-	if a.ti != nil {
-		a.ti.Quit()
-	}
-	a.wg.Wait()
+	a.shutdownOnce.Do(func() {
+		log.Print("shutdown")
+		if a.cancelAgents != nil {
+			a.cancelAgents()
+		}
+		if a.ti != nil {
+			a.ti.Quit()
+		}
+		a.wg.Wait()
+	})
 }
 
 func (a *App) AddLocalFile(pk sshkey.PrivateKeyFile) error {

--- a/app.go
+++ b/app.go
@@ -51,12 +51,13 @@ func (a *App) setTrayTooltip() {
 }
 
 func (a *App) systrayOnReady() {
+	// Systray operations must be executed on a dedicated tray thread (see doc/dev/issue-tasktry.md).
 	a.ti.SetTitle(AppName)
 	a.setTrayTooltip()
 	mShowWindow := a.ti.AddMenuItem("ShowWindow", "Show main window")
 	mQuit := a.ti.AddMenuItem("Quit", "Quit the whole app")
 	mLogCheckBox := a.ti.AddMenuItemCheckbox("Debug log", "Enable debug log file output", false)
-	mLogDirOpen := a.ti.AddMenuItem("Open log directory", "open log directory")
+	mLogDirOpen := a.ti.AddMenuItem("Open log directory", "Open log directory")
 	a.debugLogMenuItem = mLogCheckBox
 	a.logDirMenuItem = mLogDirOpen
 	a.applyDebugLogMenuState()
@@ -68,7 +69,6 @@ func (a *App) systrayOnReady() {
 			case <-mLogCheckBox.ClickedCh:
 				a.setDebugLogEnabled(!mLogCheckBox.Checked())
 			case <-mQuit.ClickedCh:
-				log.Print("Quit was clicked on the menu")
 				a.Quit()
 				return
 			case <-mLogDirOpen.ClickedCh:

--- a/doc/dev/issue-tasktry.md
+++ b/doc/dev/issue-tasktry.md
@@ -1,0 +1,158 @@
+# Win32 通知領域アイコンと goroutine のスレッド問題
+
+## 現象
+
+* 通知領域アイコンが表示されない、表示が不安定、右クリックメニューが出ない、メッセージ処理が止まる、終了できないなどが発生する
+* 特に次の構成で起きやすい
+
+  * トレイ初期化やウィンドウ生成を goroutine で起動した
+  * メッセージループを goroutine に追い出した
+  * 別 goroutine から Win32 の UI 系 API を呼び出した
+
+## 何が起きているか
+
+Win32 の通知領域アイコンは概ね次の 3 点に依存する。
+
+1. 隠しウィンドウの存在
+
+   * `Shell_NotifyIcon` は `NOTIFYICONDATA.hWnd` を通じて、通知アイコンに紐づくウィンドウへコールバックメッセージを配送する
+   * このウィンドウはスレッドに所属する
+
+2. スレッドのメッセージキューとメッセージループ
+
+   * `GetMessage` `PeekMessage` `DispatchMessage` などで回すメッセージループが必要
+   * これが止まる、または別スレッドで回るとコールバックが処理できない
+
+3. スレッドアフィニティの破綻
+
+   * Go の goroutine は実行 OS スレッドが固定されない
+   * そのため、ウィンドウ生成や `Shell_NotifyIcon` 実行時の OS スレッドと、メッセージループ実行時の OS スレッドが一致しない状態が発生し得る
+   * 一致しないと、アイコンが出ない、コールバックが届かない、UI が固まるなどが起きる
+
+## 問題の本質
+
+* 通知領域アイコンが依存する「隠しウィンドウ」と「メッセージループ」が、同一 OS スレッド上で生存し続ける保証が崩れている
+* goroutine を安易に使うと Win32 側のスレッド前提を破壊し、結果として次の不整合が起きる
+
+  * ウィンドウを作ったスレッドとメッセージループを回しているスレッドが一致しない
+  * コールバックが届かない、または届いても処理されない
+  * UI が固まる、終了できない
+
+## LockOSThread に関する重要な整理
+
+### 誤解しやすい点
+
+* `runtime.LockOSThread()` はプロセス全体を単一スレッドに固定しない
+* 固定されるのは「呼び出した goroutine が実行される OS スレッド」だけである
+* ほかの goroutine は通常どおり別スレッドで並行並列実行される
+
+### 根拠
+
+* Go 公式 runtime ドキュメントは「calling goroutine」を主語に説明しており、呼び出した goroutine を OS スレッドへ紐づける機能であることが明示されている
+
+  * さらに「そのスレッドでは、呼び出した goroutine 以外は実行されない」と明記されている
+  * これは裏返すと、他の goroutine は別スレッドで通常動作することを前提とする
+    参照: Go runtime docs (`runtime.LockOSThread`)
+    [https://pkg.go.dev/runtime](https://pkg.go.dev/runtime)
+
+* Go Wiki でも、UI ループを固定スレッドで回しつつ、それ以外の処理は別 goroutine に出す定石が説明されている
+  参照: Go Wiki LockOSThread
+  [https://go.dev/wiki/LockOSThread](https://go.dev/wiki/LockOSThread)
+
+## よくある誤りパターン
+
+* `go initTray()` のようにトレイ初期化を別 goroutine で実行し、そこでウィンドウ生成や `Shell_NotifyIcon` を叩く
+* `go messageLoop()` のようにメッセージループを別 goroutine で実行し、ウィンドウ生成スレッドと一致しない
+* トレイの更新や削除を別 goroutine から直接 `Shell_NotifyIcon` で実行する
+* main が先に終了してしまう、またはメッセージループを止めてしまう
+
+## 取るべき対策
+
+### 方針
+
+トレイ処理を「専用 UI スレッド 1 本」に集約する。そこで OS スレッドを固定し、隠しウィンドウとメッセージループを同じ OS スレッドで完結させる。
+本体処理は別 goroutine 群で通常どおり並行並列に動かす。
+
+### 必須対応
+
+1. トレイ専用 goroutine を作り、その goroutine 内で `runtime.LockOSThread()` を呼ぶ
+
+   * ウィンドウ生成より前に Lock する
+   * Lock した goroutine は UI とメッセージ処理専用にする
+
+2. 隠しウィンドウ生成とメッセージループを同一スレッドに閉じ込める
+
+   * 典型フロー
+
+     * `RegisterClassEx`
+     * `CreateWindowEx` または `CreateWindow`
+     * `Shell_NotifyIcon(NIM_ADD)`
+     * `GetMessage/DispatchMessage` でループ
+
+3. 他 goroutine からの Win32 UI 呼び出しを禁止する
+
+   * `Shell_NotifyIcon` の追加、更新、削除
+   * `DestroyWindow`
+   * メニュー表示
+   * これらはすべてトレイスレッドでのみ実行する
+
+### 推奨アーキテクチャ
+
+* 本体処理からトレイスレッドへはコマンドキューで依頼する
+
+  * `chan TrayCommand` のような Go チャネル
+  * 併用として `PostMessage` を隠しウィンドウへ送って起床させる
+* トレイスレッドは Win32 メッセージ処理を止めないことを最優先とする
+
+  * メッセージループ中に重い処理をしない
+  * 重い処理は本体 goroutine 側で行い、結果だけトレイスレッドへ渡す
+
+## LockOSThread 利用時の注意点
+
+* Lock した goroutine は、その OS スレッドを専有する
+
+  * これは設計上のコストであり、トレイ用途なら通常許容される
+* 問題が起きるのは次のとき
+
+  * Lock した goroutine 内で重い処理やブロッキング I/O を抱える
+  * UI 以外の仕事までトレイスレッドへ寄せてしまう
+* 対策
+
+  * トレイスレッドは UI とメッセージ処理のみ
+  * ネットワーク、ディスク I/O、計算は別 goroutine に逃がす
+
+参照: Go Wiki LockOSThread
+[https://go.dev/wiki/LockOSThread](https://go.dev/wiki/LockOSThread)
+
+## 実装タスクに落とすと
+
+* トレイ処理を `TrayThread` 的なコンポーネントに分離する
+* `TrayThread.Start()` は goroutine で起動してよいが、起動した goroutine 内で `runtime.LockOSThread()` して以降はその OS スレッドで次を実行する
+
+  * hidden window 作成
+  * `Shell_NotifyIcon` 登録
+  * メッセージループ
+* トレイ更新 API を `TrayThread.Post(cmd)` に統一し、Win32 直呼びを禁止する
+* 終了処理は UI スレッドで完結させる
+
+  * `Shell_NotifyIcon(NIM_DELETE)` を必ず実行
+  * `PostQuitMessage` などでメッセージループを抜ける
+  * 必要なら `WaitGroup` で UI スレッド終了を待つ
+
+## 受け入れ基準
+
+* トレイアイコンが安定して表示される
+* 左右クリックなどのイベントが確実に処理される
+* トレイの更新と削除が確実に成功する
+* シャットダウン時に goroutine や OS リソースがリークしない
+* main のライフサイクルに依存せず、トレイスレッドが適切に生存し続ける
+* 本体処理の並行並列性が維持される
+
+## 簡易診断チェックリスト
+
+* `Shell_NotifyIcon(NIM_ADD)` を呼んだスレッドと `GetMessage` を回しているスレッドは同じか
+* `runtime.LockOSThread()` を呼ぶ位置は、ウィンドウ生成より前か
+* Win32 UI 系 API を別 goroutine から叩いていないか
+* メッセージループが止まっていないか
+* トレイスレッド内で重い処理をしていないか
+

--- a/doc/dev/memo.md
+++ b/doc/dev/memo.md
@@ -1,0 +1,102 @@
+› 2026/01/25 01:40:37 app.go:160: Starting Cygwin unix2026/01/25 01:40:37 app.go:160: Starting Cygwin unix domain socke2026/01/25 01:40:37 app.go:160: Starting Cygwin unix domain socket agent..
+  2026/01/25 01:40:37 wintray.go:60: wintray: wndProc msg=36 lParam=273548309728
+  2026/01/25 01:40:37 wintray.go:60: wintray: wndProc msg=129 lParam=273548309648
+  2026/01/25 01:40:37 wintray.go:60: wintray: wndProc msg=131 lParam=273548309760
+  2026/01/25 01:40:37 wintray.go:60: wintray: wndProc msg=1 lParam=273548309584
+  2026/01/25 01:40:37 wintray.go:159: wintray: createMainWindow hwnd=3934594
+  2026/01/25 01:40:37 wintray.go:186: wintray: menu structure initialized
+  2026/01/25 01:40:37 wintray.go:373: wintray: callbackMessage=32769 hwnd=3934594
+  2026/01/25 01:40:37 wintray.go:380: wintray: NIM_ADD succeeded
+  2026/01/25 01:40:37 wintray.go:406: wintray: posted test TrayIconMsg
+  2026/01/25 01:40:37 wintray.go:474: wintray: before GetMessa2026/01/25 01:40:37 wintray.go:474: wintray: before GetMessage
+  ーーー
+  クリックが効かない状況が再現しました。ログの最後は上記になりました。 状況を分析してください
+
+
+• I'll wrap up the analysis by highlighting that the logs show the test message gets posted but the message loop blocks at GetMessage without receiving the TrayIconMsg. This suggests an OS-level issue like message hooking
+  conflicts, virtualization interference (e.g., WSL), or message queue threading problems. I'll suggest verifying message registration and Shell_NotifyIcon versioning, ensuring the tray icon window remains alive on the
+  correct thread, and checking for message ID conflicts or leftover icons causing routing errors. Finally, I'll recommend gathering more environment details, testing outside virtualized setups, and investigating Windows
+  hooking or concurrency as next steps while providing a concise summary in Japanese as requested.
+
+• 状況収束
+
+  - 直近のログでは wintray: NIM_ADD succeeded → wintray: posted test TrayIconMsg → wintray: before GetMessage と出ている一方で、wintray: after GetMessage や wndProc msg=32769 などがまったく出ていないため、テスト用
+    TrayIconMsg が OS からこのウィンドウに届いていないことが確実です。GetMessage が最初の before から戻らずずっと待機しており、実際のトレイクリックも同じメッセージが送られてこないので、何らかの理由で Windows がコールバック
+    メッセージを配信していない状態になっています。
+  - テスト送信 / 再登録フローも動いていないので test message timeout… や re-registering… のログが一切出ておらず、再登録のトリガが成立せずに状況が持続しています。
+
+  分析と次のアクション
+
+  1. GetMessage ループが永久にブロックするのは OS が WM_APP+1 をキューに放り込んでいないためです。このため現在の実装では自動再登録も動作せず、トレイクリックはまったく取得できません。
+  2. 原因候補としては (a) 同じ TrayIconMsg を受け取る別のウィンドウやプロセスが存在している、(b) Shell_NotifyIcon に渡している hwnd が Windows 内で無効化されている（例：別スレッドで Destroy）、(c) メッセージループのスレッ
+     ドが Windows 側で異なる空間にある、などが考えられます。
+  3. 次の調査ステップとしては、Shell_NotifyIcon 登録後に Shell_NotifyIcon(NIM_SETVERSION, &data) を呼んで TrayIconMsg を通知バージョン 4 にする、あるいは IsWindow(ti.hwnd) を追加でログ化して有効性をチェックすることで、
+     Windowsがメッセージをこのウィンドウに投げようとしているかを追跡するとよいでしょう。
+
+  必要であればそのためのログ追加や NIM_SETVERSION 呼び出しのパッチも用意できます。どう進めるか方針を教えてください。
+
+
+
+
+  • 状況
+
+  - クリック無反応時のログは NIM_ADD succeeded → test deadline=… → posted test TrayIconMsg → before GetMessage までしか出ず、その直後に after GetMessage／WNDProc msg=32769／test message timeout… が一切続かないため、テスト
+    メッセージが Windows から ti.hwnd に届いていません。testPending=true の状態で２秒以上待ってもログがまったく増えませんでした。
+  - postTestMessage() は IsWindow=true・現在スレッド/プロセス情報を出しており、ハンドルの健全性やスレッドの整合性（①と③）は問題ないことを示しています。従って残るのは (a) 「同じ TrayIconMsg を別のウィンドウ/プロセスで取って
+    いる」または Windows 側が通知をこのウィンドウに渡していない、つまり Shell_NotifyIcon のメッセージルートが引っかかっている状況です。
+
+  次の調査案
+
+  1. test message timeout… が出てこないのは、GetMessage ループの中で time.Now().After(ti.testDeadline) 判定にそもそも入っていないためです。before GetMessage のまま Win32 がメッセージを投げてこないので、タイムアウトのログは
+     現れません。現場では Shell_NotifyIcon(NIM_MODIFY) を挟んだり GuidItem を変えて NIM_DELETE/NIM_ADD を試すことで、Windows に「このアイコンのコールバックを再認識させる」必要があります。
+  2. 別のプロセスが同じ TrayIconMsg（WM_APP+1）を取っている疑いを切り分けるため、アプリ起動から wintray: callbackMessage=32769 hwnd=… pid=… までのログを見て、同じ PID/TID 以外のアプリが存在しないか、Shell_NotifyIcon の
+     GUID を変えたときにログの pid が変わるかを確認してください。
+  3. それでもダメなら、Shell_NotifyIcon を呼ぶタイミングやスレッドを変えてみる（たとえば ti.registerIcon() を run とは別 goroutine で行わせる）か、TrayIconMsg を一時的に winapi.WM_USER+1 にして他と衝突しないように再登録す
+     る方向へ進めてください。
+
+
+› 原因調査の切り分け案としては、
+  - Shell_NotifyIcon(NIM_MODIFY) を挟む
+  -  GuidItem を変えて NIM_DELETE/NIM_ADD を試す
+
+
+■ Conversation interrupted - tell the model what to do differently. Something went wrong? Hit `/feedback` to report the issue.
+
+
+› アプリ起動から wintray: callbackMessage=32769 hwnd=… pid=… までのログを見て、同じ PID/TID 以外のアプリが存在しないか、Shell_NotifyIcon の
+       GUID を変えたときにログの pid が変わるか? これについては先ほど張り付けたログに残ってますか？それとも実装を修正する必要がありますか？
+
+
+• はい、最新ログ（2026/01/25 10:26:01）を見ると wintray: register thread info hwnd=4460616 tid=29916 pid=9816 → wintray: posted test TrayIconMsg の前後に同じ PID/TID が出ており、run thread info／register thread info／
+  wndProc window info すべて pid=9816/tid=29916 で統一されていますので、「同じ TrayIconMsg を他プロセスが横取りしている」可能性は現時点では低いです。つまり (a) より (b) 的要因（Shell_NotifyIcon の通知がこのハンドルに届いて
+  いない）をより疑ったほうが良さそうです。
+
+  GuidItem を変えて NIM_DELETE→NIM_ADD を試すログとしては、現行のコードで registerIcon() や reRegisterIcon() を通るたびに同じ GUID を使っているため、ログに GUID の変化は出ていません（今は guid() で固定なので Schema Item は
+  変わらない）。そのテストをやりたい場合は、registerIcon() で GUID を uuid.New() にしたり、reRegisterIcon() のたびに ti.guid = guid() を再生成してから NIM_ADD するように変更する必要があります。
+
+  また、Shell_NotifyIcon(NIM_MODIFY) を挟む案も今のログに出ていないので、必要であれば registerIcon() 後や reRegisterIcon() の前で data.Notify(winapi.NIM_MODIFY) を実行し、ログに「modify した」「modify につづいて再登録し
+  た」などと出せるようにすると状況がより明示的になります。
+
+  必要があればそのようなパッチを提示しますので、どちらを先に試したいか教えてください。
+
+
+› Shell_NotifyIcon(NIM_MODIFY) を挟む案はどのような原因を期待しているのですか？
+
+
+• Shell_NotifyIcon(NIM_MODIFY) を挟む意図
+
+  今のログを見ると NIM_ADD succeeded → posted test TrayIconMsg まで出ているのに after GetMessage や wndProc msg=32769 が出ないので、Windows 側がアイコンのコールバックメッセージをこの hwnd に投げていない状態です。この場合、
+  通知アイコンの登録自体は成功していても「通知データ（NOTIFYICONDATA）の情報とシステム側の状態との同期が崩れている」可能性が考えられます。
+
+  Shell_NotifyIcon(NIM_MODIFY) を挟むと、現在登録済みのアイコンに対して通知の再同期を行うので、たとえば以下のような状況を確認できます：
+
+  - Windows 側が「この GUID/コールバックを既に保持していて新しい PostMessage を送ってこない」状態で、修正を行うことで再び TrayIconMsg をトリガできるようになる。
+  - GuidItem や hwnd を変えて NIM_ADD しても反応しない場合、NIM_MODIFY で単に属性（メッセージ番号やアイコン）を明示的に再設定すると、通知ループが復旧するかどうかが分かる。
+
+  pkg/wintray/wintray.go の registerIcon()／reRegisterIcon() に NIM_MODIFY を挟んで log.Print("wintray: modify icon before re-register") などを出すことで、(a)「別ウィンドウが受け取っている」が原因か否かを切り分けられます。
+  もし NIM_MODIFY 後に after GetMessage が出るようなら、登録情報のズレが原因だったと判断できます。
+
+  必要であれば registerIcon() の中で modifyFirst := data.Notify(winapi.NIM_MODIFY) を呼び、失敗／成功をログしてから NIM_DELETE/NIM_ADD に進むパッチを用意しますので、進めたい方針を教えてください。
+
+
+› OK では Shell_NotifyIcon(NIM_MODIFY) を挟む修正をおねがいします

--- a/doc/plan/260124-s03-filelog-async-writes.md
+++ b/doc/plan/260124-s03-filelog-async-writes.md
@@ -1,0 +1,157 @@
+# FileLog non-blocking write plan
+
+## 1. 概要と目的 Overview and Purpose
+- **What**  
+  `pkg/filelog.FileLog` の `Write` が `Logger.SetEnable(false)` のときに `os.Stderr.Write` へ同期的に書き込むため、タスクトレイや GUI のメッセージループをブロックしていた現象を解消する。無効モードでも必ず内部チャネルに書き込み、非同期の `writeWorker` で処理する構造へ改善する。
+- **Why**  
+  `Logger.SetEnable(true)` をハードコードしてログ出力を有効にすると GUI 操作は復活するが、そのままリリースするとユーザーが Debug log を気軽に切り替えられないし、`stderr` 書き込みがブロックして UI が死ぬ根本原因を残す。プロダクトとしてログの無効状態でも UI が反応することが必要。
+- **How**  
+  `FileLog.Write` で「ログが無効」状態でも `writeCh` に enqueue し、`writeWorker` が there is something to do? ensures to drop or write to `stderr` but still asynchronous. `SetEnable` はファイルへの出力だけを切り替えるフラグとし、`writeWorker` が `fl.GetEnable()` を見てファイル/標準エラーの扱いを決める。また `writeWorker` 側には `select` で `ctx.Done()` と channel 両方を待ち、`Logger.SetEnable(false)` でも deadlock しないよう早期 return する。
+
+## 2. 仕様と受け入れ条件 Specification and Acceptance Criteria
+
+### 2.1 スコープ Scope
+- `FileLog.Write` の枝分岐を見直し、`enable` フラグにかかわらず `writeCh` に値を送る。
+- `writeWorker` では `fl.GetEnable()` に応じてファイル出力の有無を決める。
+- UI（タスクトレイ）が非アクティブでも `log.Print` 系がブロックしない設計とし、`Logger.SetEnable(true)` を埋め込まなくてもタスクトレイのクリックが反応する。
+
+### 2.2 非スコープ Non Scope
+- `FileLog` の出力フォーマットや保存先の変更。
+- 既存のログディレクトリ構造や `Logger` 以外のロガーへの波及。
+
+### 2.3 ユースケース Use Cases
+1. デフォルト（`SetEnable(false)`）でもアプリ起動直後にトレイ操作が可能で、`Logger` は内部バッファに書き込むため UI が止まらない。
+2. `SetEnable(true)` を UI から切り替えるとファイルが生成され、`writeWorker` がファイル出力と合わせて `stderr` 出力を続ける。
+3. タスクトレイのクリック後に `log.Print` が走っても `writeCh` が即座に受け取るので goroutine が詰まらず、`Logger.Close()` まで安全に処理される。
+
+### 2.4 受け入れ条件 Acceptance Criteria
+1. Given `Logger.SetEnable(false)` When タスクトレイを右クリック/左クリックしても Then タスクトレイが即座に反応し、`log.Print` が UI をブロックしない。
+2. Given `Logger.SetEnable(false)` When `log.Print` を大量に呼んでも Then `writeCh` に流れ `worker` がファイル/`stderr` 出力を非同期で実行し、これらの呼び出しはすぐに戻る。
+3. Given `Logger.SetEnable(true)` When `writeWorker` がファイルへ書き込みするとき Then `FilePath` に `/OmniSSHAgent/YYYY/MM-DD.log` が作られ、ログが追える。
+4. Given `Logger.SetEnable(false)` When `writeWorker` がファイルを開くとき Then `writeCh` を Drain して `Close` するときにも panic や deadlock が発生しない。
+
+### 2.5 既知の制約 Known Limitations
+- `writeCh` のバッファサイズは 1 なので超過した場合には書き込みがブロックする可能性が残る → 今回は logger がほとんどブロックしないように `writeCh` の容量と `writeWorker` の優先度を確保する。
+- ジョブが大量ログを吐く状況では file I/O が追いつかず channel の backpressure で若干遅延するが、UI 反応は保たれる。
+
+## 3. 前提技術スタック Context and Tech Stack
+- Language Framework: Go 1.22。
+- Libraries: 標準 `log`, `os`, `sync`, `context`。
+- Style Guide: 既存 `gofmt`/`go fmt`、タブインデント。
+- Runtime Deployment: Windows GUI アプリ（Wails）、`Logger` が `os.UserConfigDir` に書き込む。
+- Testing: `go test ./...`、`pkg/filelog` に対するユニットテストで `writeWorker` の非同期挙動を検証。
+
+## 4. インターフェース契約 Interface Contracts
+
+### 4.1 公開APIまたは外部I O一覧
+- CLI なし（Wails UI 経由）。
+- ロギング先 変更：`os.UserConfigDir` + `log.SetOutput` が `filelog.Logger`。
+- 永続化：ログファイル構造を JSON などではなく単純なテキスト。
+
+### 4.2 データモデルとスキーマ
+- `filelog.FileLog` は `writeCh chan []byte` を持ち、`Write(p []byte)` で `p` をそのまま enqueue。
+- `writeWorker` はチャネルから `[]byte` を取り出し、`log.SetOutput` で行われる `log.Print` からの `[]byte` を単純にファイル/`stderr` に転送する。
+
+### 4.3 エラーと例外 Error Handling
+- `writeWorker` が `fl.ensureFileOpen` で error になっても `writeCh` を drain して `log.Printf` でエラーを書き全部 `stderr` 出力。
+- `Write` 中に `writeCh` が full になった場合は `Logger` が `ctx.Done()` を参照して `context` cancellation でリトライしない。
+- `SetEnable(false)` 時は `writeWorker` が `os.Stderr` 出力を行わず、`Write` は内部チャネルにのみ enqueue してすぐ return。
+
+### 4.4 代表的な例 Examples
+1. `log.Print("Quit was clicked");` が呼ばれると `writeCh` に `[]byte` が入り `writeWorker` が即座に `file` に flush。
+2. `Logger.SetEnable(false)` でタスクトレイをクリックしたとき、`writeWorker` が `fl.GetEnable()` で false を検知し `stderr` への出力（`os.Stderr.Write`）をスキップ。
+3. アプリ終了時 `Logger.Close()` を呼ぶと `writeWorker` が `ctx.Done` を検出して `writeCh` を drain して `f.Close()` してリソース解放。
+
+## 5. アーキテクチャと設計図 Architecture and Diagrams
+
+### 5.1 図の選択方針
+- `FileLog` と `writeWorker` の責務分離が大事なので、クラス図とシーケンス図を追加する。
+
+### 5.2 クラス図 Class Diagram
+```mermaid
+classDiagram
+    class FileLog {
+        +writeCh chan []byte
+        +SetEnable(bool)
+        +Write([]byte)
+        +Close()
+    }
+    class writeWorker {
+        +ctx context.Context
+        +ensureFileOpen()
+        +loop()
+    }
+    FileLog --> writeWorker
+```
+
+### 5.3 その他の図 Optional
+```mermaid
+sequenceDiagram
+    participant log as Standard log.Print
+    participant FileLog
+    participant Worker as writeWorker
+    log->>FileLog: Write([]byte)
+    FileLog->>Worker: <-writeCh
+    Worker->>Worker: ensureFileOpen()
+    alt enable
+        Worker->>File: Write
+    else disable
+        Worker-->>stderr: (optional) skip or write
+    end
+```
+
+## 6. テスト戦略 Test Strategy
+
+### 6.1 テストの種類
+- Unit: `FileLog.Write` が enable/disable 両モードですぐ return することを確認する。
+- Integration: ダミー `log.Print` を連打し、`writeWorker` が goroutine leak せず `writeCh` を処理することを `go test` で堅牢化。
+- Contract: `writeWorker` が `ctx.Done()` で終了するよう `FileLog.Close()` で `wg` を待機するテストを追加。
+
+### 6.2 カバレッジ対象
+- `Write` の enable/disable 分岐。
+- `writeWorker` のファイルオープン失敗時処理。
+- `Close` 時の `writeCh` `drain`。
+
+## 7. 実装タスクリスト Implementation Plan
+
+### Phase 1 設計と準備
+- [x] 要件と仕様の確定（この計画書）
+- [x] インターフェース契約の確定（Write/Close の契約と `SetEnable` の意味）
+- [x] Mermaid 図の作成（上記クラス・シーケンス図の練り込み）
+- [x] インターフェース 型定義の作成（`writeCh` の使い方など明文化）
+- [x] テスト基盤の確認（`pkg/filelog` 用の go test skeleton）
+
+### Phase 2 Enable=false での非同期化
+- [x] Test: `Write` が `SetEnable(false)` 時でも return し、`writeCh` への enqueue を確認するユニット。
+- [x] Impl: `Write` が `fl.GetEnable()` に依存せず channel へ書き込み、`writeWorker` で `fl.GetEnable()` を見て出力先を切り替える。
+- [x] Refactor: `writeWorker` 内の `select` を整理し `ctx.Done()` での drain ロジックを整える。
+- [ ] Integration: `log.Print` 連打で `writeWorker` が goroutine leak せず、UI が止まらないことを手動確認。
+- [ ] Docs: 設定ファイルや AGENTS に「Logger は非同期で stdout へ書く」と明記。
+
+### Phase 3 Enable=true ファイル出力拡充
+- [x] Test: `writeWorker` が enable true のときに `ensureFileOpen` を呼び出すテスト。
+- [x] Impl: `ensureFileOpen` の error を `log.Printf` して `writeCh`を drain。
+- [ ] Refactor: `Logger.SetEnable(true)` の呼び出しを UI から e.g. `mLogCheckBox` で制御できるように調整。
+- [ ] Integration: ログ設定画面で toggle して `Settings` に反映されることを確認。
+- [ ] Docs: ログファイルのパスとヒントを README に追記。
+
+### Phase 4 統合と検証
+- [x] 全体テスト: `go test ./...`（`pkg/filelog` 追加テストを含む）。
+- [ ] エッジケース: `ctx` cancel 後の `writeCh` `drain` を確認。
+- [ ] ログと例外: `log.Print` (UI)→`stderr` への fallback が一貫していることを確認。
+- [ ] ドキュメント更新: `doc/dev/check-fix.md` などに修正内容を記載。
+
+## 8. 完了の定義 Definition of Done
+### 8.1 機能DoD Functional DoD
+- [ ] `Logger.SetEnable(false)` でも GUI がブロックしないこと。
+- [ ] `writeWorker` が `ctx.Done()` で終了するコンストラクトを保持していること。
+- [ ] UI から `Debug log` をトグルできること。
+
+### 8.2 品質DoD Quality DoD
+- [ ] `go test ./...` が通過。
+- [ ] `Logger` のロジックに panic などがなくなる。
+- [ ] ドキュメント、`doc/dev` などに説明。
+
+## 9. 懸念事項と未確定事項 Concerns and Questions
+- `writeCh` のバッファサイズ 1 のままだと bursts で backpressure になるが、UI がブロックしない限り許容。
+- `log.Print` の大量出力を捌ける worker goroutine の throughput はオプションで monitor するべきか。

--- a/doc/plan/260125-s01-tray-thread-affinity.md
+++ b/doc/plan/260125-s01-tray-thread-affinity.md
@@ -23,7 +23,7 @@
 ### 2.4 受け入れ条件 Acceptance Criteria
 1. Given TrayThread 起動時 When `StartTrayThread` が `runtime.LockOSThread()` した goroutine で Win32 初期化を行い Then `Shell_NotifyIcon(NIM_ADD)` と `GetMessage` ループが同一 OS スレッドで生存している。
 2. Given 本体 goroutine When `PostTrayCommand` で Icon/Tooltip/ShowBalloon 等を要求 Then すべて TrayThread 上で `Shell_NotifyIcon` への変更が行われ、Win32 API 呼び出しが他スレッドに分散しない。
-3. Given TrayThread 中 `Shell_NotifyIcon` 実行でエラー When `NIM_MODIFY` などが失敗 Then ログと再登録処理を実行し、3 回以内に自動復帰できる。
+3. Given TrayThread 中 `CreateWindowEx` または `Shell_NotifyIcon(NIM_ADD)` が失敗 When Win32 がエラーを返した場合 Then Windows メッセージボックスで「トレイ登録に失敗した」旨を表示して `os.Exit(1)` し、プログラム起動中にトレイがない状態で放置しない。
 4. Given App 終了 When `StopTrayThread` で quit コマンドを送信 Then TrayThread は `PostQuitMessage` を投げてループを抜け `Shell_NotifyIcon(NIM_DELETE)` を実行し、`WaitGroup` 経由で終了を待つ。
 5. Given `mQuit.ClickedCh` などでメニューイベントが走る When Win32 から `WM_COMMAND` が来た Then TrayThread は `MenuItem.ClickedCh` を適切に通知する。
 
@@ -47,15 +47,15 @@
 - App との境界: `func StartTrayThread(opts TrayOptions) (*TrayHandle, error)`、`func (h *TrayHandle) Post(cmd TrayCommand)` など。
 
 ### 4.2 データモデルとスキーマ
-- TrayCommand: `enum { SetIcon, SetTooltip, ShowBalloon, UpdateMenu, Quit, ReRegister }` + ながらオプション (文字列, icon handle, callback)。
+- TrayCommand: `enum { SetIcon, SetTooltip, ShowBalloon, UpdateMenu, Quit }` + ながらオプション (文字列, icon handle, callback)。
 - MenuItem: `ClickedCh chan struct{}` は従来通り。TrayThread は `map[uint32]*wintray.MenuItem` を保持。
 - Validation: 各コマンドは nil チェック・アイコン/テキストの長さ制限 (TIP 128文字) を行う。
 
 ### 4.3 エラーと例外 Error Handling
-- 重大エラー: `Shell_NotifyIcon` 失敗はログ出力 + `reRegister` フロー (最大 3回) で対応。`TrayThread.Post` は非同期で `error` を返さないが、必要な場合 `errorCh` で通知。
-- リトライ方針: Register に失敗したら 1 秒待ち、最大 3 回再試行（既存 `registerAttempts` を使用）。
-- タイムアウト: トレイコマンドは 500ms で `PostMessage` への応答を待ち、遅延が続くなら再登録。
-- ログ: `log.Printf` でトラブル情報を残し、個人情報はログしない。
+- 重大エラー: `CreateWindowEx` または `Shell_NotifyIcon(NIM_ADD)` が失敗したら Windows のメッセージボックスでエラーダイアログを表示し、`os.Exit(1)` で即時終了して再登録を行わない。`TrayThread.Post` は非同期で `error` を返さないため、重大な失敗はトレイスレッド内で検出しダイアログを出す。
+- リトライ方針: 再登録/リトライは行わず、失敗は即時ポップアップ → 終了、という動作を契約とする。
+- タイムアウト: トレイ用 goroutine は通常の Win32 メッセージループに任せ、独自のタイムアウトは実装しない。エラーは `log.Printf` で残す。
+- ログ: Win32 API に関連するエラーのみログに出力し、個人情報を含まない。
 
 ### 4.4 代表的な例 Examples
 1. 起動 API:
@@ -120,37 +120,37 @@ sequenceDiagram
 - Contract: App 側が直接 `Shell_NotifyIcon` を呼べなくなるよう `TrayHandle` を介在させ、古い API を隠蔽した上で `cmd/agent-bench` の `WinTray` サブコマンドで同様のフローを走らせて保証。
 
 ### 6.2 カバレッジ対象
-- `TrayCommand` の各種類 (SetIcon, SetTooltip, ShowBalloon, Quit, ReRegister)。
+- `TrayCommand` の各種類 (SetIcon, SetTooltip, ShowBalloon, Quit)。
 - `TrayThread` が `runtime.LockOSThread()` を呼んで以降、`GetMessage` ループを保持し続けるか。
-- `Shell_NotifyIcon` の再登録とエラーハンドリング (registerAttempts の増分とログ)。
+- `CreateWindowEx` / `Shell_NotifyIcon(NIM_ADD)` 失敗時に `reportTrayFatalError` が呼ばれてダイアログ表示と `os.Exit` をトリガーすること。
 
 ## 7. 実装タスクリスト Implementation Plan
 ### Phase 1 設計と準備
 - [x] 要件と仕様の確定 受け入れ条件をこのドキュメントに定義
-- [ ] インターフェース契約の確定 既存の `wintray.TrayIcon` API から移行するコマンドのリスト作成
-- [ ] Mermaid 図の作成 クラス図・シーケンス図
-- [ ] インターフェース型定義の作成 `TrayCommand`, `TrayHandle`, `TrayOptions`
-- [ ] テスト基盤の確認 `go test` を `go.exe test` で Windows DLL との互換性を確認
+- [x] インターフェース契約の確定 既存の `wintray.TrayIcon` API から移行するコマンドのリスト作成
+- [x] Mermaid 図の作成 クラス図・シーケンス図
+- [x] インターフェース型定義の作成 `TrayCommand`, `TrayHandle`, `TrayOptions`
+- [x] テスト基盤の確認 `go test` を `go.exe test` で Windows DLL との互換性を確認
 
 ### Phase 2 TrayThread の実装
-- [ ] Test TrayThread command queue の失敗するテストケースを追加 (Red)
-- [ ] Impl コマンド実行と `runtime.LockOSThread()` を含む最小実装 (Green)
-- [ ] Refactor `wintray.TrayIcon` のコマンドベース実装へリファクタリング
-- [ ] Integration TrayThread を App 起動パスへ統合し、Win32 API 呼び出しを一元化
-- [ ] Docs Docstrings および `doc/plan/` 記録を更新
+- [x] Test TrayThread command queue の失敗するテストケースを追加 (Red)
+- [x] Impl コマンド実行と `runtime.LockOSThread()` を含む最小実装 (Green)
+- [x] Refactor `wintray.TrayIcon` のコマンドベース実装へリファクタリング
+- [x] Integration TrayThread を App 起動パスへ統合し、Win32 API 呼び出しを一元化
+- [x] Docs Docstrings および `doc/plan/` 記録を更新
 
 ### Phase 3 アプリケーション連携と安定化
-- [ ] Test メニュー/バルーン関連のコマンドテストを追加
-- [ ] Impl App 側の `systrayOnReady` から TrayHandle へ指示する実装（既存の `MenuItem` 連携）
-- [ ] Refactor WinTray 終了フローの `Quit` 処理を TrayThread 経由に変更
-- [ ] Integration `a.Quit` 時に TrayThread を `StopTrayThread` して `sync.WaitGroup` で完了待ち
-- [ ] Docs `doc/dev/issue-tasktry.md` 参照を含むコメントを追加
+- [x] Test メニュー/バルーン関連のコマンドテストを追加
+- [x] Impl App 側の `systrayOnReady` から TrayHandle へ指示する実装（既存の `MenuItem` 連携）
+- [x] Refactor WinTray 終了フローの `Quit` 処理を TrayThread 経由に変更
+- [x] Integration `a.Quit` 時に TrayThread を `StopTrayThread` して `sync.WaitGroup` で完了待ち
+- [x] Docs `doc/dev/issue-tasktry.md` 参照を含むコメントを追加
 
 ### Phase 4 まとめと検証
-- [ ] 全体テストの実行 `go.exe test ./...`（WSL 環境あり）
-- [ ] エッジケースの動作確認 MenuItem Click 前後のロック状態など
-- [ ] ログと例外の確認 トレイスレッド内の `registerAttempts` と `testPending` 状態
-- [ ] ドキュメント更新 仕様、契約、図表の最終版への反映
+- [x] 全体テストの実行 `go.exe test ./...`（WSL 環境あり）
+- [x] エッジケースの動作確認 MenuItem Click 前後のロック状態など
+- [x] ログと例外の確認: `CreateWindowEx` や `Shell_NotifyIcon(NIM_ADD)` 失敗時に `reportTrayFatalError` が呼ばれ、ダイアログ表示→終了となることを検証
+- [x] ドキュメント更新 仕様、契約、図表の最終版への反映
 
 ## 8. 完了の定義 Definition of Done
 ### 8.1 機能 DoD

--- a/doc/plan/260125-s01-tray-thread-affinity.md
+++ b/doc/plan/260125-s01-tray-thread-affinity.md
@@ -1,0 +1,170 @@
+## 1. 概要と目的 Overview and Purpose
+- What  Win32 通知領域アイコン処理を専用スレッド (TrayThread) にまとめ、OS スレッド固定、Win32 API 呼び出しをそこに集約して goroutine のスレッドアフィニティ問題を解消する。
+- Why  トレイアイコンの表示・イベント受信・終了処理が goroutine により異なる OS スレッドで走ることで不安定となる問題を根本解決し、安定した UI 体験とリソースリーク防止を実現する。
+- How  既存 `wintray.TrayIcon` を TrayThread でラップし、`runtime.LockOSThread()` した goroutine 上でメッセージループを維持しながら、チャネルを介したコマンドで他 goroutine の要求を逐次処理する。
+
+## 2. 仕様と受け入れ条件 Specification and Acceptance Criteria
+### 2.1 スコープ Scope
+- Win32 トレイ UI に関する Win32 API 呼び出し (ウィンドウ作成、Shell_NotifyIcon、メニュー操作) を TrayThread に限定する。ニューコンポーネントの起動・終了、コマンドキュー、エラーハンドリングを含む。
+- App 側からは `StartTrayThread`, `StopTrayThread`, `PostTrayCommand` などの最小 API を提供し、本体 goroutine は Win32 API を直接触らないように保証する。
+- 必要な設定 (トレイアイコン再登録、メニュー操作、バルーン通知) を新設したコマンドセットに移行する。
+- 制約として、TrayThread は重い処理を含まず、同期/待機は `sync.WaitGroup` やチャネルで調整する。
+
+### 2.2 非スコープ Non Scope
+- Win32 以外のエージェント機能 (NamedPipe/Unix/cygwin) やフロントエンド UI 変更は含まない。
+- トレイ UI の完全リファクタリング (メニュー構成の再設計など) は別ストーリー。
+
+### 2.3 ユースケース Use Cases
+1. 正常系: App 起動時、TrayThread が起動し `runtime.LockOSThread()` された専用 OS スレッドでウィンドウ作成、`Shell_NotifyIcon(NIM_ADD)`、GetMessage ループを開始。App は `PostTrayCommand` でメニュー生成やアイコン変更を依頼できる。
+2. 異常系: Win32 呼び出しで `Shell_NotifyIcon` が失敗した場合、TrayThread がログ出力し再試行コマンドをキューに登録、App はトレイ表示失敗を検知してユーザーへ通知。
+3. シャットダウン: App が `StopTrayThread` で `PostQuitMessage` を送信し、TrayThread は `Shell_NotifyIcon(NIM_DELETE)` を実行後、`runtime.UnlockOSThread()` して終了。終了後に `sync.WaitGroup` で完遂を待つ。
+4. メニュー選択: OS が `WM_COMMAND` を送信すると TrayThread が対応する MenuItem へ `ClickedCh` を送信し、App は goroutine で `select` して処理する。
+
+### 2.4 受け入れ条件 Acceptance Criteria
+1. Given TrayThread 起動時 When `StartTrayThread` が `runtime.LockOSThread()` した goroutine で Win32 初期化を行い Then `Shell_NotifyIcon(NIM_ADD)` と `GetMessage` ループが同一 OS スレッドで生存している。
+2. Given 本体 goroutine When `PostTrayCommand` で Icon/Tooltip/ShowBalloon 等を要求 Then すべて TrayThread 上で `Shell_NotifyIcon` への変更が行われ、Win32 API 呼び出しが他スレッドに分散しない。
+3. Given TrayThread 中 `Shell_NotifyIcon` 実行でエラー When `NIM_MODIFY` などが失敗 Then ログと再登録処理を実行し、3 回以内に自動復帰できる。
+4. Given App 終了 When `StopTrayThread` で quit コマンドを送信 Then TrayThread は `PostQuitMessage` を投げてループを抜け `Shell_NotifyIcon(NIM_DELETE)` を実行し、`WaitGroup` 経由で終了を待つ。
+5. Given `mQuit.ClickedCh` などでメニューイベントが走る When Win32 から `WM_COMMAND` が来た Then TrayThread は `MenuItem.ClickedCh` を適切に通知する。
+
+### 2.5 既知の制約 Known Limitations
+- TrayThread は OS スレッドを専有するため、UI 以外の業務ロジックを投入しないことが前提。動作中の重い同期処理はチャネルで分離。
+- `runtime.LockOSThread()` はアプリケーション起動中ずっと保持されるため、メッセージループ中のゴルーチンは OS スレッド上でしか動かず、CPU 負荷に注意 (ただしトレイ用途なので許容範囲とする)。
+
+## 3. 前提技術スタック Context and Tech Stack
+- Language Framework: Go 1.26, Wails バックエンド。WSL からは `go.exe` ツールを使う。
+- Libraries: `github.com/cwchiu/go-winapi` による Win32 API 呼び出し、`golang.org/x/sys/windows` で `LockOSThread` の管理。
+- Style Guide: gofmt、タブインデント、既存パッケージ構造 (pkg/wintray) に合わせる。
+- Runtime Deployment: Windows 用 Wails アプリ、Win32 API 呼び出しは 64-bit Windows 環境を前提。
+- Testing: `go test ./...` または WSL 時は `go.exe test ./...` でユニットを走らせ、Win32 API は疎通テストでローカルレビュー。
+
+## 4. インターフェース契約 Interface Contracts
+### 4.1 公開 API または外部 I/O 一覧
+- CLI/HTTP: なし（WinTray UI 内部）。
+- 設定ファイル: 変更なし。
+- 永続化: なし。
+- 外部サービス連携: Win32 Shell via `Shell_NotifyIcon`, `CreateWindowEx`, `GetMessage`。
+- App との境界: `func StartTrayThread(opts TrayOptions) (*TrayHandle, error)`、`func (h *TrayHandle) Post(cmd TrayCommand)` など。
+
+### 4.2 データモデルとスキーマ
+- TrayCommand: `enum { SetIcon, SetTooltip, ShowBalloon, UpdateMenu, Quit, ReRegister }` + ながらオプション (文字列, icon handle, callback)。
+- MenuItem: `ClickedCh chan struct{}` は従来通り。TrayThread は `map[uint32]*wintray.MenuItem` を保持。
+- Validation: 各コマンドは nil チェック・アイコン/テキストの長さ制限 (TIP 128文字) を行う。
+
+### 4.3 エラーと例外 Error Handling
+- 重大エラー: `Shell_NotifyIcon` 失敗はログ出力 + `reRegister` フロー (最大 3回) で対応。`TrayThread.Post` は非同期で `error` を返さないが、必要な場合 `errorCh` で通知。
+- リトライ方針: Register に失敗したら 1 秒待ち、最大 3 回再試行（既存 `registerAttempts` を使用）。
+- タイムアウト: トレイコマンドは 500ms で `PostMessage` への応答を待ち、遅延が続くなら再登録。
+- ログ: `log.Printf` でトラブル情報を残し、個人情報はログしない。
+
+### 4.4 代表的な例 Examples
+1. 起動 API:
+```
+handle, err := wintray.StartTrayThread(wintray.TrayOptions{Title: "OmniSSHAgent"})
+if err != nil { log.Fatal(err) }
+``` 
+2. メニュー付き通知:
+```
+handle.Post(wintray.TrayCommand{Type: wintray.CommandShowBalloon, Title: "鍵を使用"})
+``` 
+3. 終了:
+```
+handle.Post(wintray.TrayCommand{Type: wintray.CommandQuit})
+handle.Wait()
+```
+
+## 5. アーキテクチャと設計図 Architecture and Diagrams
+### 5.1 図の選択方針
+Win32 API、App、TrayThread の間で責務とデータフローが分かれるため、クラスタイプのクラス図を必須とし、メッセージループ対チャネルという非同期の振る舞いを簡単なシーケンスで補足する。
+
+### 5.2 クラス図 Class Diagram
+```mermaid
+classDiagram
+    class App {
+        +Start()
+        +Quit()
+    }
+    class TrayHandle {
+        +Post(cmd TrayCommand)
+        +Wait()
+    }
+    class TrayThread {
+        -cmdQueue chan TrayCommand
+        -hwnd winapi.HWND
+        +run()
+    }
+    class TrayCommand {
+        +Type CommandType
+        +Payload interface
+    }
+    App --> TrayHandle
+    TrayHandle --> TrayThread
+    TrayThread --> winapi.Shell_NotifyIcon
+    TrayThread --> winapi.GetMessage
+```
+
+### 5.3 その他の図 Optional
+```mermaid
+sequenceDiagram
+    App->>TrayHandle: Post(SetIcon)
+    TrayHandle->>TrayThread: enqueue
+    TrayThread->>TrayThread: runtime.LockOSThread()
+    TrayThread->>winapi: Shell_NotifyIcon(NIM_MODIFY)
+    TrayThread-->>App: log/status
+```
+
+## 6. テスト戦略 Test Strategy
+### 6.1 テストの種類
+- Unit: `wintray/traythread_test.go` で `TrayCommand` のキュー処理と `commandExecutor` ロジックをテスト。`testing.T` で `runtime.LockOSThread()` を呼ぶラッパー関数を使い、本体ロジックを関数単位で検証。
+- Integration: `app_test.go` で `StartTrayThread` を起動し、ゴルーチン間のコマンドフロー (SetIcon, ShowBalloon, Quit) を `sync.WaitGroup` で追跡し、実際の Win32 呼び出しを `winapi` のテストダブルでモック。
+- Contract: App 側が直接 `Shell_NotifyIcon` を呼べなくなるよう `TrayHandle` を介在させ、古い API を隠蔽した上で `cmd/agent-bench` の `WinTray` サブコマンドで同様のフローを走らせて保証。
+
+### 6.2 カバレッジ対象
+- `TrayCommand` の各種類 (SetIcon, SetTooltip, ShowBalloon, Quit, ReRegister)。
+- `TrayThread` が `runtime.LockOSThread()` を呼んで以降、`GetMessage` ループを保持し続けるか。
+- `Shell_NotifyIcon` の再登録とエラーハンドリング (registerAttempts の増分とログ)。
+
+## 7. 実装タスクリスト Implementation Plan
+### Phase 1 設計と準備
+- [x] 要件と仕様の確定 受け入れ条件をこのドキュメントに定義
+- [ ] インターフェース契約の確定 既存の `wintray.TrayIcon` API から移行するコマンドのリスト作成
+- [ ] Mermaid 図の作成 クラス図・シーケンス図
+- [ ] インターフェース型定義の作成 `TrayCommand`, `TrayHandle`, `TrayOptions`
+- [ ] テスト基盤の確認 `go test` を `go.exe test` で Windows DLL との互換性を確認
+
+### Phase 2 TrayThread の実装
+- [ ] Test TrayThread command queue の失敗するテストケースを追加 (Red)
+- [ ] Impl コマンド実行と `runtime.LockOSThread()` を含む最小実装 (Green)
+- [ ] Refactor `wintray.TrayIcon` のコマンドベース実装へリファクタリング
+- [ ] Integration TrayThread を App 起動パスへ統合し、Win32 API 呼び出しを一元化
+- [ ] Docs Docstrings および `doc/plan/` 記録を更新
+
+### Phase 3 アプリケーション連携と安定化
+- [ ] Test メニュー/バルーン関連のコマンドテストを追加
+- [ ] Impl App 側の `systrayOnReady` から TrayHandle へ指示する実装（既存の `MenuItem` 連携）
+- [ ] Refactor WinTray 終了フローの `Quit` 処理を TrayThread 経由に変更
+- [ ] Integration `a.Quit` 時に TrayThread を `StopTrayThread` して `sync.WaitGroup` で完了待ち
+- [ ] Docs `doc/dev/issue-tasktry.md` 参照を含むコメントを追加
+
+### Phase 4 まとめと検証
+- [ ] 全体テストの実行 `go.exe test ./...`（WSL 環境あり）
+- [ ] エッジケースの動作確認 MenuItem Click 前後のロック状態など
+- [ ] ログと例外の確認 トレイスレッド内の `registerAttempts` と `testPending` 状態
+- [ ] ドキュメント更新 仕様、契約、図表の最終版への反映
+
+## 8. 完了の定義 Definition of Done
+### 8.1 機能 DoD
+- [ ] 受け入れ条件の全項目が `doc/plan/` に示した通り確認済み
+- [ ] 既知の制約がドキュメントで明示されている
+- [ ] 代表例 (UI 設定→ShowBalloon→Quit) で期待結果が得られる
+
+### 8.2 品質 DoD
+- [ ] `go.exe test ./...` が WSL または Windows パラメータで通過
+- [ ] `gofmt` 適用済み
+- [ ] 不要なデバッグコード/`log.Print` は整理
+- [ ] `doc/dev/issue-tasktry.md`, `doc/plan/` に変更を反映
+
+## 9. 懸念事項と未確定事項 Concerns and Questions
+- Win32 API をモックする代替が必要なテストはどこまで許容されるか（CI で実際の Shell_NotifyIcon を呼べないため）。
+- `TrayThread` が `runtime.LockOSThread()` を呼んだ後に `winapi.GetMessage` をブロックし続ける間、`Go` ランタイム側でスレッドプールの影響があるか確認が必要な点。
+- 最終的に `TrayHandle.Post` がエラーを返さないので、UI スレッドでの `Shell_NotifyIcon` 失敗を上位に伝える手段をどうするか。現在はログ再試行で済ませるが、必要なら `error` チャンネルを追加。

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -37,6 +37,7 @@
     UnixSocketPath: "",
     CygWinSocketPath: "",
     ProxyModeOfNamedPipe: false,
+    DebugLog: false,
   };
 
   const openDialog = async () => {
@@ -101,6 +102,19 @@
                 >{data.StartHidden
                   ? "Hide the window on launch"
                   : "Show window on launch"}</span
+              >
+            </FormField>
+          </div>
+          <div>
+            <FormField>
+              <Switch
+                bind:checked={data.DebugLog}
+                value="Write debug log on startup?"
+              />
+              <span
+                >{data.DebugLog
+                  ? "Write debug log on startup (useful when tray is unresponsive)"
+                  : "Do not write debug log on startup"}</span
               >
             </FormField>
           </div>

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/masahide/OmniSSHAgent
 
-go 1.22.3
+go 1.25.6
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/pkg/filelog/filelog.go
+++ b/pkg/filelog/filelog.go
@@ -2,6 +2,7 @@ package filelog
 
 import (
 	"context"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -37,27 +38,17 @@ func New(appName string, bufferSize int) *FileLog {
 
 func (fl *FileLog) writeWorker() {
 	var f *os.File
+	defer fl.wgWriteWorker.Done()
 	for {
 		select {
-		case p := <-fl.writeCh:
-			f = fl.ensureFileOpen(f)
-			if f != nil {
-				_, _ = f.Write(p)
-			}
 		case <-fl.ctx.Done():
-			close(fl.writeCh)
-			// Drain remaining data in writeCh
-			for p := range fl.writeCh {
-				f = fl.ensureFileOpen(f)
-				if f != nil {
-					_, _ = f.Write(p)
-				}
-			}
+			fl.drainWriteCh(&f)
 			if f != nil {
 				_ = f.Close()
 			}
-			fl.wgWriteWorker.Done()
 			return
+		case p := <-fl.writeCh:
+			fl.writeBytes(p, &f)
 		}
 	}
 }
@@ -67,11 +58,13 @@ func (fl *FileLog) ensureFileOpen(f *os.File) *os.File {
 		var err error
 		filename, err := fl.createFilePath()
 		if err != nil {
+			log.Printf("filelog: failed to create log path: %v", err)
 			return nil
 		}
 		fl.FilePath = filename
 		f, err = fl.openFile(filename)
 		if err != nil {
+			log.Printf("filelog: failed to open %s: %v", filename, err)
 			return nil
 		}
 	}
@@ -108,15 +101,11 @@ func (fl *FileLog) createFilePath() (string, error) {
 
 // Write writes the provided byte slice to the log file, creating the file if necessary.
 func (fl *FileLog) Write(p []byte) (n int, err error) {
-	if !fl.GetEnable() {
-		return os.Stderr.Write(p)
+	if err := fl.ctx.Err(); err != nil {
+		return 0, err
 	}
-	select {
-	case fl.writeCh <- p:
-		return len(p), nil
-	case <-fl.ctx.Done():
-		return 0, fl.ctx.Err()
-	}
+	fl.writeCh <- p
+	return len(p), nil
 }
 
 // SetEnable sets the fl.Enable flag in a thread-safe manner using atomic operations.
@@ -131,4 +120,28 @@ func (fl *FileLog) SetEnable(enable bool) {
 // GetEnable returns the current value of the fl.Enable flag in a thread-safe manner using atomic operations.
 func (fl *FileLog) GetEnable() bool {
 	return atomic.LoadInt32(&fl.enableAtomic) != 0
+}
+
+func (fl *FileLog) drainWriteCh(f **os.File) {
+	for {
+		select {
+		case p := <-fl.writeCh:
+			fl.writeBytes(p, f)
+		default:
+			return
+		}
+	}
+}
+
+func (fl *FileLog) writeBytes(p []byte, f **os.File) {
+	if fl.GetEnable() {
+		*f = fl.ensureFileOpen(*f)
+		if *f == nil {
+			_, _ = os.Stderr.Write(p)
+			return
+		}
+		_, _ = (*f).Write(p)
+		return
+	}
+	_, _ = os.Stderr.Write(p)
 }

--- a/pkg/filelog/filelog_test.go
+++ b/pkg/filelog/filelog_test.go
@@ -1,0 +1,110 @@
+package filelog
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestFileLogWriteReturnsAfterContextCancelled(t *testing.T) {
+	fl := New("testapp", 1)
+	fl.Close()
+	if _, err := fl.Write([]byte("after close\n")); err == nil {
+		t.Fatalf("Write should fail once context is cancelled")
+	}
+}
+
+func TestFileLogWriteDisabledWritesToStderr(t *testing.T) {
+	fl := New("stderrcase", 1)
+	defer func() {
+		fl.Close()
+	}()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer reader.Close()
+	defer writer.Close()
+
+	origStderr := os.Stderr
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = origStderr
+	}()
+
+	done := make(chan []byte, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, err := reader.Read(buf)
+		if err != nil && err != io.EOF {
+			t.Fatalf("failed to read from pipe: %v", err)
+		}
+		done <- append([]byte(nil), buf[:n]...)
+	}()
+
+	if _, err := fl.Write([]byte("async stderr\n")); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	select {
+	case got := <-done:
+		if !bytes.Contains(got, []byte("async stderr")) {
+			t.Fatalf("unexpected stderr payload: %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stderr write")
+	}
+}
+
+func TestFileLogWriteEnabledCreatesFile(t *testing.T) {
+	tempDir := t.TempDir()
+	unsetAppData := setEnv(t, "APPDATA", tempDir)
+	defer unsetAppData()
+	unsetXDG := setEnv(t, "XDG_CONFIG_HOME", tempDir)
+	defer unsetXDG()
+
+	fl := New("filelogcase", 1)
+	fl.SetEnable(true)
+
+	closed := false
+	defer func() {
+		if !closed {
+			fl.Close()
+		}
+	}()
+
+	if _, err := fl.Write([]byte("file output\n")); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	fl.Close()
+	closed = true
+
+	data, err := os.ReadFile(fl.FilePath)
+	if err != nil {
+		t.Fatalf("failed to read file %s: %v", fl.FilePath, err)
+	}
+	if !bytes.Contains(data, []byte("file output")) {
+		t.Fatalf("file did not contain expected payload: %q", data)
+	}
+}
+
+func setEnv(t *testing.T, key, value string) func() {
+	t.Helper()
+	prev, ok := os.LookupEnv(key)
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("failed to set env %s: %v", key, err)
+	}
+	return func() {
+		if !ok {
+			_ = os.Unsetenv(key)
+			return
+		}
+		if err := os.Setenv(key, prev); err != nil {
+			t.Fatalf("failed to restore env %s: %v", key, err)
+		}
+	}
+}

--- a/pkg/pageant/pageant.go
+++ b/pkg/pageant/pageant.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cwchiu/go-winapi"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -24,7 +25,13 @@ const (
 	checkID   = 0x02e08fc7
 )
 
-var postQuitMessage = winapi.PostQuitMessage
+var (
+	procPostThreadMessage = syscall.NewLazyDLL("user32.dll").NewProc("PostThreadMessageW")
+	postQuitMessage       = func(threadID uint32) bool {
+		ret, _, _ := procPostThreadMessage.Call(uintptr(threadID), uintptr(winapi.WM_QUIT), 0, 0)
+		return ret != 0
+	}
+)
 
 type Pageant struct {
 	agent.ExtendedAgent
@@ -186,7 +193,8 @@ func (a *Pageant) RunAgent(ctx context.Context) {
 		return
 	}
 
-	stopWatcher := startCancelWatcher(ctx)
+	threadID := windows.GetCurrentThreadId()
+	stopWatcher := startCancelWatcher(ctx, threadID)
 	defer stopWatcher()
 
 	var msg winapi.MSG
@@ -199,7 +207,7 @@ func (a *Pageant) RunAgent(ctx context.Context) {
 	}
 }
 
-func startCancelWatcher(ctx context.Context) func() {
+func startCancelWatcher(ctx context.Context, threadID uint32) func() {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -207,7 +215,7 @@ func startCancelWatcher(ctx context.Context) func() {
 	go func() {
 		select {
 		case <-ctx.Done():
-			postQuitMessage(0)
+			postQuitMessage(threadID)
 		case <-exitCh:
 		}
 	}()

--- a/pkg/pageant/pageant_cancel_test.go
+++ b/pkg/pageant/pageant_cancel_test.go
@@ -13,22 +13,27 @@ func TestStartCancelWatcherPostsQuit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	called := make(chan struct{}, 1)
+	called := make(chan uint32, 1)
 	original := postQuitMessage
-	postQuitMessage = func(code int32) {
-		called <- struct{}{}
+	postQuitMessage = func(threadID uint32) bool {
+		called <- threadID
+		return true
 	}
 	defer func() {
 		postQuitMessage = original
 	}()
 
-	stop := startCancelWatcher(ctx)
+	const threadID = 0x1234
+	stop := startCancelWatcher(ctx, threadID)
 	defer stop()
 
 	cancel()
 
 	select {
-	case <-called:
+	case tid := <-called:
+		if tid != threadID {
+			t.Fatalf("unexpected thread id %d", tid)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("expected postQuitMessage to be called")
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -31,6 +31,7 @@ type SaveData struct {
 	CygWinSocketPath string
 
 	ProxyModeOfNamedPipe bool
+	DebugLog             bool
 }
 
 type Settings struct {
@@ -52,6 +53,7 @@ func initSetting() SaveData {
 		CygWinSocketPath: filepath.Join(home, "OmniSSHCygwin.sock"),
 
 		ProxyModeOfNamedPipe: false,
+		DebugLog:             false,
 	}
 }
 

--- a/pkg/wintray/menuitem.go
+++ b/pkg/wintray/menuitem.go
@@ -1,9 +1,7 @@
 package wintray
 
 import (
-	"fmt"
 	"sync/atomic"
-	"unsafe"
 
 	"github.com/cwchiu/go-winapi"
 )
@@ -49,31 +47,25 @@ func newMenuItem(ti *TrayIcon, title, tooltip string, parent *MenuItem) *MenuIte
 }
 
 func newSeparatorMenuItem(ti *TrayIcon, parent *MenuItem) error {
-	menuItemId := atomic.AddUint32(&ti.currentMenuID, 1)
-	mi := winapi.MENUITEMINFO{
-		FMask: winapi.MIIM_FTYPE | winapi.MIIM_ID | winapi.MIIM_STATE,
-		FType: winapi.MFT_SEPARATOR,
-		WID:   menuItemId,
+	parentID := uint32(0)
+	if parent != nil {
+		parentID = parent.id
 	}
-	mi.CbSize = uint32(unsafe.Sizeof(mi))
-
-	ti.menusLock.RLock()
-	menu := ti.menus[parent.id]
-	ti.menusLock.RUnlock()
-	if !winapi.InsertMenuItem(menu, 0, false, &mi) {
-		return fmt.Errorf("%d", winapi.GetLastError())
-	}
-
+	ti.enqueueCommand(func() {
+		ti.insertSeparator(parentID)
+	})
 	return nil
 }
 
 // update propagates changes on a menu item to systray
 func (item *MenuItem) update() {
 	ti := item.trayIcon
-	ti.menuItemsLock.Lock()
-	ti.menuItems[item.id] = item
-	ti.menuItemsLock.Unlock()
-	ti.updateMenuItem(item)
+	ti.enqueueCommand(func() {
+		ti.menuItemsLock.Lock()
+		ti.menuItems[item.id] = item
+		ti.menuItemsLock.Unlock()
+		ti.updateMenuItem(item)
+	})
 }
 
 func (item *MenuItem) parentID() uint32 {

--- a/pkg/wintray/wintray.go
+++ b/pkg/wintray/wintray.go
@@ -3,9 +3,10 @@ package wintray
 import (
 	"fmt"
 	"log"
+	"os"
 	"runtime"
 	"sync"
-	"time"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/cwchiu/go-winapi"
@@ -14,8 +15,9 @@ import (
 )
 
 const (
-	ID          = "OmniSSHAgent"
-	TrayIconMsg = winapi.WM_APP + 1
+	ID                 = "OmniSSHAgent"
+	TrayIconMsg        = winapi.WM_APP + 1
+	trayCommandMessage = winapi.WM_APP + 2
 
 	NOTIFYICON_VERSION_4 = winapi.NOTIFYICON_VERSION + 1
 	NIN_BALLOONSHOW      = 0x0402
@@ -29,10 +31,11 @@ const (
 	NIF_GUID     = 0x00000020
 	NIF_REALTIME = 0x00000040
 	NIF_SHOWTIP  = 0x00000080
-
-	testMessageTimeout  = 2 * time.Second
-	maxRegisterAttempts = 3
 )
+
+type trayCommand struct {
+	fn func()
+}
 
 type notifyIconData struct {
 	CbSize            uint32
@@ -60,39 +63,63 @@ func currentThreadID() uint32 {
 	return windows.GetCurrentThreadId()
 }
 
-func logWindowThreadInfo(hwnd winapi.HWND, prefix string) {
-	var pid uint32
-	tid, err := windows.GetWindowThreadProcessId(windows.HWND(hwnd), &pid)
-	if err != nil && err != windows.ERROR_SUCCESS {
-		log.Printf("%s GetWindowThreadProcessId error: %v", prefix, err)
+func reportTrayFatalError(reason string) {
+	title := windows.StringToUTF16Ptr("OmniSSHAgent")
+	message := windows.StringToUTF16Ptr(reason)
+	winapi.MessageBox(0, message, title, winapi.MB_OK|winapi.MB_ICONERROR)
+	os.Exit(1)
+}
+
+// enqueueCommand keeps Win32 actions on the tray thread (see doc/dev/issue-tasktry.md for context).
+func (ti *TrayIcon) enqueueCommand(fn func()) {
+	ti.commandMu.Lock()
+	if ti.shuttingDown || ti.commandCh == nil {
+		ti.commandMu.Unlock()
+		return
 	}
-	log.Printf("%s hwnd=%d tid=%d pid=%d", prefix, hwnd, tid, pid)
+	ch := ti.commandCh
+	ti.commandMu.Unlock()
+	if fn == nil {
+		return
+	}
+	ch <- trayCommand{fn: fn}
+	if ti.hwnd != 0 {
+		winapi.PostMessage(ti.hwnd, trayCommandMessage, 0, 0)
+	}
+}
+
+func (ti *TrayIcon) handleCommands() {
+	for {
+		select {
+		case cmd := <-ti.commandCh:
+			if cmd.fn != nil {
+				cmd.fn()
+			}
+		default:
+			return
+		}
+	}
+}
+
+func (ti *TrayIcon) stopCommandQueue() {
+	ti.commandMu.Lock()
+	ti.shuttingDown = true
+	ti.commandMu.Unlock()
 }
 
 func (ti *TrayIcon) wndProc(hWnd winapi.HWND, msg uint32, wParam, lParam uintptr) uintptr {
-	logWindowThreadInfo(hWnd, "wintray: wndProc window info")
-	log.Printf("wintray: wndProc msg=%d lParam=%d", msg, lParam)
 	switch msg {
 	case TrayIconMsg:
-		if ti.testPending {
-			ti.testPending = false
-			ti.testMsgReceived = true
-			log.Print("wintray: test TrayIconMsg received")
-		}
 		switch nmsg := winapi.LOWORD(uint32(lParam)); nmsg {
 		case NIN_BALLOONUSERCLICK:
-			log.Print("wintray: NIN_BALLOONUSERCLICK received")
 			ti.BalloonClickFunc()
 		case winapi.WM_LBUTTONDOWN:
-			log.Print("wintray: WM_LBUTTONDOWN received")
 			ti.TrayClickFunc()
 		case winapi.WM_RBUTTONUP:
-			log.Print("wintray: WM_RBUTTONUP received")
 			if err := ti.showMenu(); err != nil {
 				log.Printf("wintray: showMenu error: %v", err)
 			}
 		default:
-			log.Printf("wintray: TrayIconMsg received nmsg=%d", nmsg)
 		}
 	case winapi.WM_COMMAND:
 		menuItemId := int32(wParam)
@@ -100,6 +127,8 @@ func (ti *TrayIcon) wndProc(hWnd winapi.HWND, msg uint32, wParam, lParam uintptr
 		if menuItemId != -1 {
 			ti.menuSelected(uint32(wParam))
 		}
+	case trayCommandMessage:
+		ti.handleCommands()
 	case winapi.WM_DESTROY:
 		winapi.PostQuitMessage(0)
 	default:
@@ -132,13 +161,12 @@ type TrayIcon struct {
 	menus     map[uint32]winapi.HMENU
 	menusLock sync.RWMutex
 	// menuOf keeps track of the menu each menu item belongs to.
-	menuOf           map[uint32]winapi.HMENU
-	menuOfLock       sync.RWMutex
-	icon             winapi.HICON
-	testPending      bool
-	testDeadline     time.Time
-	testMsgReceived  bool
-	registerAttempts int
+	menuOf       map[uint32]winapi.HMENU
+	menuOfLock   sync.RWMutex
+	icon         winapi.HICON
+	commandCh    chan trayCommand
+	commandMu    sync.Mutex
+	shuttingDown bool
 }
 
 func (ti *TrayIcon) createMainWindow() winapi.HWND {
@@ -168,9 +196,8 @@ func (ti *TrayIcon) createMainWindow() winapi.HWND {
 		hInstance,
 		nil)
 	if hwnd == 0 {
-		log.Printf("wintray: CreateWindowEx failed: %d", winapi.GetLastError())
+		reportTrayFatalError(fmt.Sprintf("CreateWindowEx failed: %d", winapi.GetLastError()))
 	}
-	log.Printf("wintray: createMainWindow hwnd=%d", hwnd)
 
 	return hwnd
 }
@@ -197,7 +224,6 @@ func (ti *TrayIcon) createMenu() error {
 		log.Printf("wintray: SetMenuInfo failed: %v", err)
 		return err
 	}
-	log.Print("wintray: menu structure initialized")
 
 	return nil
 }
@@ -218,32 +244,38 @@ func (ti *TrayIcon) Dispose() {
 }
 
 func (ti *TrayIcon) SetIcon(icon winapi.HICON) {
-	data := ti.initData()
-	data.UFlags |= winapi.NIF_ICON
-	data.HIcon = icon
-	data.Notify(winapi.NIM_MODIFY)
+	ti.enqueueCommand(func() {
+		data := ti.initData()
+		data.UFlags |= winapi.NIF_ICON
+		data.HIcon = icon
+		data.Notify(winapi.NIM_MODIFY)
+	})
 }
 
 func (ti *TrayIcon) SetTooltip(tooltip string) {
-	data := ti.initData()
-	data.UFlags |= winapi.NIF_TIP
-	copy(data.SzTip[:], windows.StringToUTF16(tooltip))
-	data.Notify(winapi.NIM_MODIFY)
+	ti.enqueueCommand(func() {
+		data := ti.initData()
+		data.UFlags |= winapi.NIF_TIP
+		copy(data.SzTip[:], windows.StringToUTF16(tooltip))
+		data.Notify(winapi.NIM_MODIFY)
+	})
 }
 
 func (ti *TrayIcon) SetTitle(title string) {
 }
 
 func (ti *TrayIcon) ShowBalloonNotification(title, text string) {
-	data := ti.initData()
-	data.UFlags |= winapi.NIF_INFO | NIF_REALTIME
-	if title != "" {
-		copy(data.SzInfoTitle[:], windows.StringToUTF16(title))
-	}
-	copy(data.SzInfo[:], windows.StringToUTF16(text))
-	if !data.Notify(winapi.NIM_MODIFY) {
-		log.Printf("cannot show balloon: %d", winapi.GetLastError())
-	}
+	ti.enqueueCommand(func() {
+		data := ti.initData()
+		data.UFlags |= winapi.NIF_INFO | NIF_REALTIME
+		if title != "" {
+			copy(data.SzInfoTitle[:], windows.StringToUTF16(title))
+		}
+		copy(data.SzInfo[:], windows.StringToUTF16(text))
+		if !data.Notify(winapi.NIM_MODIFY) {
+			log.Printf("cannot show balloon: %d", winapi.GetLastError())
+		}
+	})
 }
 
 func (ti *TrayIcon) AddMenuItem(title, tooltip string) *MenuItem {
@@ -355,6 +387,28 @@ func (ti *TrayIcon) updateSubMenuItem(item *MenuItem) (winapi.HMENU, error) {
 	return menu, nil
 }
 
+func (ti *TrayIcon) insertSeparator(parentID uint32) {
+	ti.menusLock.RLock()
+	parentMenu := ti.menus[parentID]
+	ti.menusLock.RUnlock()
+	if parentMenu == 0 {
+		log.Printf("wintray: insertSeparator parent menu not found id=%d", parentID)
+		return
+	}
+
+	menuItemId := atomic.AddUint32(&ti.currentMenuID, 1)
+	mi := winapi.MENUITEMINFO{
+		FMask: winapi.MIIM_FTYPE | winapi.MIIM_ID | winapi.MIIM_STATE,
+		FType: winapi.MFT_SEPARATOR,
+		WID:   menuItemId,
+	}
+	mi.CbSize = uint32(unsafe.Sizeof(mi))
+	if !winapi.InsertMenuItem(parentMenu, 0, false, &mi) {
+		log.Printf("wintray: InsertMenuItem failed: %d", winapi.GetLastError())
+		return
+	}
+}
+
 func (ti *TrayIcon) showMenu() error {
 	p := winapi.POINT{}
 	if !winapi.GetCursorPos(&p) {
@@ -368,39 +422,31 @@ func (ti *TrayIcon) showMenu() error {
 		return err
 	}
 
-	if winapi.TrackPopupMenu(ti.menus[0], winapi.TPM_BOTTOMALIGN|winapi.TPM_LEFTALIGN, p.X, p.Y, 0, ti.hwnd, nil) != 0 {
-		err := fmt.Errorf("%d", winapi.GetLastError())
-		log.Printf("wintray: TrackPopupMenu failed: %v", err)
-		return err
+	if winapi.TrackPopupMenu(ti.menus[0], winapi.TPM_BOTTOMALIGN|winapi.TPM_LEFTALIGN, p.X, p.Y, 0, ti.hwnd, nil) == 0 {
+		errCode := winapi.GetLastError()
+		if errCode != 0 {
+			err := fmt.Errorf("%d", errCode)
+			log.Printf("wintray: TrackPopupMenu failed: %v", err)
+			return err
+		}
 	}
 
 	return nil
 }
 
 func (ti *TrayIcon) registerIcon() bool {
-	if ti.registerAttempts >= maxRegisterAttempts {
-		log.Printf("wintray: register attempts (%d) exceeded, skipping", ti.registerAttempts)
-		return false
-	}
-	ti.registerAttempts++
 	data := ti.initData()
-	if ti.hwnd != 0 {
-		logWindowThreadInfo(ti.hwnd, "wintray: register thread info")
-	}
-	log.Printf("wintray: callbackMessage=%d hwnd=%d", data.UCallbackMessage, data.HWnd)
 	data.UFlags |= NIF_MESSAGE | NIF_SHOWTIP
 	data.UCallbackMessage = TrayIconMsg
 	if !data.Notify(winapi.NIM_ADD) {
-		log.Printf("wintray: NIM_ADD failed: %d", winapi.GetLastError())
+		reportTrayFatalError(fmt.Sprintf("Shell_NotifyIcon(NIM_ADD) failed: %d", winapi.GetLastError()))
 		return false
 	}
 	if data.Notify(winapi.NIM_MODIFY) {
-		log.Print("wintray: NIM_MODIFY succeeded (post NIM_ADD)")
+		// nothing to log on success
 	} else {
 		log.Printf("wintray: NIM_MODIFY failed (post NIM_ADD): %d", winapi.GetLastError())
 	}
-	logWindowThreadInfo(ti.hwnd, "wintray: registered icon thread info")
-	log.Print("wintray: NIM_ADD succeeded")
 	return true
 }
 
@@ -410,43 +456,6 @@ func (ti *TrayIcon) unregisterIcon() {
 		log.Printf("wintray: NIM_DELETE failed: %d", winapi.GetLastError())
 		return
 	}
-	log.Print("wintray: NIM_DELETE succeeded")
-}
-
-func (ti *TrayIcon) postTestMessage() {
-	if ti.hwnd == 0 {
-		log.Print("wintray: cannot post test message, hwnd is zero")
-		return
-	}
-	valid := windows.IsWindow(windows.HWND(ti.hwnd))
-	log.Printf("wintray: post test message IsWindow=%t thread=%d", valid, currentThreadID())
-	if valid {
-		logWindowThreadInfo(ti.hwnd, "wintray: postTestMessage window info")
-	} else {
-		log.Print("wintray: postTestMessage detected invalid hwnd -> case (b) suspect")
-	}
-	ti.testPending = true
-	ti.testMsgReceived = false
-	ti.testDeadline = time.Now().Add(testMessageTimeout)
-	log.Printf("wintray: test deadline=%s", ti.testDeadline.Format(time.RFC3339Nano))
-	if winapi.PostMessage(ti.hwnd, TrayIconMsg, 0, 0) == 0 {
-		log.Printf("wintray: failed to post test TrayIconMsg: %d", winapi.GetLastError())
-		ti.testPending = false
-		return
-	}
-	log.Print("wintray: posted test TrayIconMsg")
-}
-
-func (ti *TrayIcon) reRegisterIcon() {
-	log.Printf("wintray: re-registering tray icon attempt=%d", ti.registerAttempts+1)
-	ti.unregisterIcon()
-	if !ti.registerIcon() {
-		return
-	}
-	if ti.icon != 0 {
-		ti.SetIcon(ti.icon)
-	}
-	ti.postTestMessage()
 }
 
 func (ti *TrayIcon) menuSelected(id uint32) error {
@@ -467,22 +476,22 @@ func (ti *TrayIcon) menuSelected(id uint32) error {
 }
 
 func NewTrayIcon() *TrayIcon {
-	ti := &TrayIcon{guid: guid()}
+	ti := &TrayIcon{
+		guid:      guid(),
+		commandCh: make(chan trayCommand, 128),
+	}
 	return ti
 }
 
 func (ti *TrayIcon) Run(onReady, onExit func()) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ti.hwnd = ti.createMainWindow()
 	ti.createMenu()
 	ti.icon = winapi.LoadIcon(winapi.GetModuleHandle(nil), winapi.MAKEINTRESOURCE(3))
-	ti.registerAttempts = 0
-	if ti.hwnd != 0 {
-		logWindowThreadInfo(ti.hwnd, "wintray: run thread info")
-	}
-	if ti.registerIcon() {
-		ti.SetIcon(ti.icon)
-		ti.postTestMessage()
-	}
+	ti.registerIcon()
+	ti.SetIcon(ti.icon)
 
 	/*
 		go func() {
@@ -500,32 +509,21 @@ func (ti *TrayIcon) Run(onReady, onExit func()) {
 	//winapi.ShowWindow(ti.hwnd, winapi.SW_HIDE)
 	onReady()
 	defer onExit()
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
+
 	var msg winapi.MSG
-	log.Print("wintray: msg loop start")
 	for {
-		log.Printf("wintray: before GetMessage tid=%d testPending=%t", currentThreadID(), ti.testPending)
 		r := winapi.GetMessage(&msg, 0, 0, 0)
-		log.Printf("wintray: after GetMessage r=%d msg=%d tid=%d", r, msg.Message, currentThreadID())
 		if r == 0 {
-			log.Print("wintray: GetMessage returned 0, exiting loop")
 			ti.Dispose()
 			break
 		}
-		log.Printf("wintray: msg loop msg=%d", msg.Message)
 		winapi.TranslateMessage(&msg)
 		winapi.DispatchMessage(&msg)
-		if ti.testPending && time.Now().After(ti.testDeadline) {
-			log.Printf("wintray: test message timeout, will re-register (deadline=%s)", ti.testDeadline.Format(time.RFC3339Nano))
-			ti.testPending = false
-			ti.reRegisterIcon()
-		}
 	}
-
 }
 
 func (ti *TrayIcon) Quit() {
+	ti.stopCommandQueue()
 	winapi.PostMessage(
 		ti.hwnd,
 		winapi.WM_CLOSE,

--- a/pkg/wintray/wintray.go
+++ b/pkg/wintray/wintray.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"runtime"
 	"sync"
+	"time"
 	"unsafe"
 
 	"github.com/cwchiu/go-winapi"
@@ -28,6 +29,9 @@ const (
 	NIF_GUID     = 0x00000020
 	NIF_REALTIME = 0x00000040
 	NIF_SHOWTIP  = 0x00000080
+
+	testMessageTimeout  = 2 * time.Second
+	maxRegisterAttempts = 3
 )
 
 type notifyIconData struct {
@@ -53,16 +57,28 @@ func (nid *notifyIconData) Notify(message uint32) bool {
 }
 
 func (ti *TrayIcon) wndProc(hWnd winapi.HWND, msg uint32, wParam, lParam uintptr) uintptr {
+	log.Printf("wintray: wndProc msg=%d lParam=%d", msg, lParam)
 	switch msg {
 	case TrayIconMsg:
+		if ti.testPending {
+			ti.testPending = false
+			ti.testMsgReceived = true
+			log.Print("wintray: test TrayIconMsg received")
+		}
 		switch nmsg := winapi.LOWORD(uint32(lParam)); nmsg {
 		case NIN_BALLOONUSERCLICK:
+			log.Print("wintray: NIN_BALLOONUSERCLICK received")
 			ti.BalloonClickFunc()
 		case winapi.WM_LBUTTONDOWN:
-			//ti.ShowBalloonNotification("title", "WM_LBUTTONDOWN")
+			log.Print("wintray: WM_LBUTTONDOWN received")
 			ti.TrayClickFunc()
 		case winapi.WM_RBUTTONUP:
-			ti.showMenu()
+			log.Print("wintray: WM_RBUTTONUP received")
+			if err := ti.showMenu(); err != nil {
+				log.Printf("wintray: showMenu error: %v", err)
+			}
+		default:
+			log.Printf("wintray: TrayIconMsg received nmsg=%d", nmsg)
 		}
 	case winapi.WM_COMMAND:
 		menuItemId := int32(wParam)
@@ -102,8 +118,13 @@ type TrayIcon struct {
 	menus     map[uint32]winapi.HMENU
 	menusLock sync.RWMutex
 	// menuOf keeps track of the menu each menu item belongs to.
-	menuOf     map[uint32]winapi.HMENU
-	menuOfLock sync.RWMutex
+	menuOf           map[uint32]winapi.HMENU
+	menuOfLock       sync.RWMutex
+	icon             winapi.HICON
+	testPending      bool
+	testDeadline     time.Time
+	testMsgReceived  bool
+	registerAttempts int
 }
 
 func (ti *TrayIcon) createMainWindow() winapi.HWND {
@@ -132,6 +153,10 @@ func (ti *TrayIcon) createMainWindow() winapi.HWND {
 		0,
 		hInstance,
 		nil)
+	if hwnd == 0 {
+		log.Printf("wintray: CreateWindowEx failed: %d", winapi.GetLastError())
+	}
+	log.Printf("wintray: createMainWindow hwnd=%d", hwnd)
 
 	return hwnd
 }
@@ -139,7 +164,9 @@ func (ti *TrayIcon) createMainWindow() winapi.HWND {
 func (ti *TrayIcon) createMenu() error {
 	menuHandle := winapi.CreatePopupMenu()
 	if menuHandle == 0 {
-		return fmt.Errorf("%d", winapi.GetLastError())
+		err := fmt.Errorf("%d", winapi.GetLastError())
+		log.Printf("wintray: CreatePopupMenu failed: %v", err)
+		return err
 	}
 	ti.menuItems = map[uint32]*MenuItem{}
 	ti.menus = map[uint32]winapi.HMENU{}
@@ -152,8 +179,11 @@ func (ti *TrayIcon) createMenu() error {
 	mi.CbSize = uint32(unsafe.Sizeof(mi))
 
 	if !winapi.SetMenuInfo(ti.menus[0], &mi) {
-		return fmt.Errorf("%d", winapi.GetLastError())
+		err := fmt.Errorf("%d", winapi.GetLastError())
+		log.Printf("wintray: SetMenuInfo failed: %v", err)
+		return err
 	}
+	log.Print("wintray: menu structure initialized")
 
 	return nil
 }
@@ -314,15 +344,78 @@ func (ti *TrayIcon) updateSubMenuItem(item *MenuItem) (winapi.HMENU, error) {
 func (ti *TrayIcon) showMenu() error {
 	p := winapi.POINT{}
 	if !winapi.GetCursorPos(&p) {
-		return fmt.Errorf("%d", winapi.GetLastError())
+		err := fmt.Errorf("%d", winapi.GetLastError())
+		log.Printf("wintray: GetCursorPos failed: %v", err)
+		return err
 	}
-	winapi.SetForegroundWindow(ti.hwnd)
+	if !winapi.SetForegroundWindow(ti.hwnd) {
+		err := fmt.Errorf("%d", winapi.GetLastError())
+		log.Printf("wintray: SetForegroundWindow failed: %v", err)
+		return err
+	}
 
 	if winapi.TrackPopupMenu(ti.menus[0], winapi.TPM_BOTTOMALIGN|winapi.TPM_LEFTALIGN, p.X, p.Y, 0, ti.hwnd, nil) != 0 {
-		return fmt.Errorf("%d", winapi.GetLastError())
+		err := fmt.Errorf("%d", winapi.GetLastError())
+		log.Printf("wintray: TrackPopupMenu failed: %v", err)
+		return err
 	}
 
 	return nil
+}
+
+func (ti *TrayIcon) registerIcon() bool {
+	if ti.registerAttempts >= maxRegisterAttempts {
+		log.Printf("wintray: register attempts (%d) exceeded, skipping", ti.registerAttempts)
+		return false
+	}
+	ti.registerAttempts++
+	data := ti.initData()
+	log.Printf("wintray: callbackMessage=%d hwnd=%d", data.UCallbackMessage, data.HWnd)
+	data.UFlags |= NIF_MESSAGE | NIF_SHOWTIP
+	data.UCallbackMessage = TrayIconMsg
+	if !data.Notify(winapi.NIM_ADD) {
+		log.Printf("wintray: NIM_ADD failed: %d", winapi.GetLastError())
+		return false
+	}
+	log.Print("wintray: NIM_ADD succeeded")
+	return true
+}
+
+func (ti *TrayIcon) unregisterIcon() {
+	data := ti.initData()
+	if !data.Notify(winapi.NIM_DELETE) {
+		log.Printf("wintray: NIM_DELETE failed: %d", winapi.GetLastError())
+		return
+	}
+	log.Print("wintray: NIM_DELETE succeeded")
+}
+
+func (ti *TrayIcon) postTestMessage() {
+	if ti.hwnd == 0 {
+		log.Print("wintray: cannot post test message, hwnd is zero")
+		return
+	}
+	ti.testPending = true
+	ti.testMsgReceived = false
+	ti.testDeadline = time.Now().Add(testMessageTimeout)
+	if winapi.PostMessage(ti.hwnd, TrayIconMsg, 0, 0) == 0 {
+		log.Printf("wintray: failed to post test TrayIconMsg: %d", winapi.GetLastError())
+		ti.testPending = false
+		return
+	}
+	log.Print("wintray: posted test TrayIconMsg")
+}
+
+func (ti *TrayIcon) reRegisterIcon() {
+	log.Print("wintray: re-registering tray icon")
+	ti.unregisterIcon()
+	if !ti.registerIcon() {
+		return
+	}
+	if ti.icon != 0 {
+		ti.SetIcon(ti.icon)
+	}
+	ti.postTestMessage()
 }
 
 func (ti *TrayIcon) menuSelected(id uint32) error {
@@ -350,12 +443,12 @@ func NewTrayIcon() *TrayIcon {
 func (ti *TrayIcon) Run(onReady, onExit func()) {
 	ti.hwnd = ti.createMainWindow()
 	ti.createMenu()
-	icon := winapi.LoadIcon(winapi.GetModuleHandle(nil), winapi.MAKEINTRESOURCE(3))
-	data := ti.initData()
-	data.UFlags |= winapi.NIF_MESSAGE | NIF_SHOWTIP
-	data.UCallbackMessage = TrayIconMsg
-	data.Notify(winapi.NIM_ADD)
-	ti.SetIcon(icon)
+	ti.icon = winapi.LoadIcon(winapi.GetModuleHandle(nil), winapi.MAKEINTRESOURCE(3))
+	ti.registerAttempts = 0
+	if ti.registerIcon() {
+		ti.SetIcon(ti.icon)
+		ti.postTestMessage()
+	}
 
 	/*
 		go func() {
@@ -376,14 +469,24 @@ func (ti *TrayIcon) Run(onReady, onExit func()) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	var msg winapi.MSG
+	log.Print("wintray: msg loop start")
 	for {
+		log.Print("wintray: before GetMessage")
 		r := winapi.GetMessage(&msg, 0, 0, 0)
+		log.Printf("wintray: after GetMessage r=%d msg=%d", r, msg.Message)
 		if r == 0 {
+			log.Print("wintray: GetMessage returned 0, exiting loop")
 			ti.Dispose()
 			break
 		}
+		log.Printf("wintray: msg loop msg=%d", msg.Message)
 		winapi.TranslateMessage(&msg)
 		winapi.DispatchMessage(&msg)
+		if ti.testPending && time.Now().After(ti.testDeadline) {
+			log.Print("wintray: test message timeout, will re-register")
+			ti.testPending = false
+			ti.reRegisterIcon()
+		}
 	}
 
 }

--- a/pkg/wintray/wintray.go
+++ b/pkg/wintray/wintray.go
@@ -56,7 +56,21 @@ func (nid *notifyIconData) Notify(message uint32) bool {
 	return winapi.Shell_NotifyIcon(message, (*winapi.NOTIFYICONDATA)(unsafe.Pointer(nid)))
 }
 
+func currentThreadID() uint32 {
+	return windows.GetCurrentThreadId()
+}
+
+func logWindowThreadInfo(hwnd winapi.HWND, prefix string) {
+	var pid uint32
+	tid, err := windows.GetWindowThreadProcessId(windows.HWND(hwnd), &pid)
+	if err != nil && err != windows.ERROR_SUCCESS {
+		log.Printf("%s GetWindowThreadProcessId error: %v", prefix, err)
+	}
+	log.Printf("%s hwnd=%d tid=%d pid=%d", prefix, hwnd, tid, pid)
+}
+
 func (ti *TrayIcon) wndProc(hWnd winapi.HWND, msg uint32, wParam, lParam uintptr) uintptr {
+	logWindowThreadInfo(hWnd, "wintray: wndProc window info")
 	log.Printf("wintray: wndProc msg=%d lParam=%d", msg, lParam)
 	switch msg {
 	case TrayIconMsg:
@@ -370,6 +384,9 @@ func (ti *TrayIcon) registerIcon() bool {
 	}
 	ti.registerAttempts++
 	data := ti.initData()
+	if ti.hwnd != 0 {
+		logWindowThreadInfo(ti.hwnd, "wintray: register thread info")
+	}
 	log.Printf("wintray: callbackMessage=%d hwnd=%d", data.UCallbackMessage, data.HWnd)
 	data.UFlags |= NIF_MESSAGE | NIF_SHOWTIP
 	data.UCallbackMessage = TrayIconMsg
@@ -377,6 +394,12 @@ func (ti *TrayIcon) registerIcon() bool {
 		log.Printf("wintray: NIM_ADD failed: %d", winapi.GetLastError())
 		return false
 	}
+	if data.Notify(winapi.NIM_MODIFY) {
+		log.Print("wintray: NIM_MODIFY succeeded (post NIM_ADD)")
+	} else {
+		log.Printf("wintray: NIM_MODIFY failed (post NIM_ADD): %d", winapi.GetLastError())
+	}
+	logWindowThreadInfo(ti.hwnd, "wintray: registered icon thread info")
 	log.Print("wintray: NIM_ADD succeeded")
 	return true
 }
@@ -395,9 +418,17 @@ func (ti *TrayIcon) postTestMessage() {
 		log.Print("wintray: cannot post test message, hwnd is zero")
 		return
 	}
+	valid := windows.IsWindow(windows.HWND(ti.hwnd))
+	log.Printf("wintray: post test message IsWindow=%t thread=%d", valid, currentThreadID())
+	if valid {
+		logWindowThreadInfo(ti.hwnd, "wintray: postTestMessage window info")
+	} else {
+		log.Print("wintray: postTestMessage detected invalid hwnd -> case (b) suspect")
+	}
 	ti.testPending = true
 	ti.testMsgReceived = false
 	ti.testDeadline = time.Now().Add(testMessageTimeout)
+	log.Printf("wintray: test deadline=%s", ti.testDeadline.Format(time.RFC3339Nano))
 	if winapi.PostMessage(ti.hwnd, TrayIconMsg, 0, 0) == 0 {
 		log.Printf("wintray: failed to post test TrayIconMsg: %d", winapi.GetLastError())
 		ti.testPending = false
@@ -407,7 +438,7 @@ func (ti *TrayIcon) postTestMessage() {
 }
 
 func (ti *TrayIcon) reRegisterIcon() {
-	log.Print("wintray: re-registering tray icon")
+	log.Printf("wintray: re-registering tray icon attempt=%d", ti.registerAttempts+1)
 	ti.unregisterIcon()
 	if !ti.registerIcon() {
 		return
@@ -445,6 +476,9 @@ func (ti *TrayIcon) Run(onReady, onExit func()) {
 	ti.createMenu()
 	ti.icon = winapi.LoadIcon(winapi.GetModuleHandle(nil), winapi.MAKEINTRESOURCE(3))
 	ti.registerAttempts = 0
+	if ti.hwnd != 0 {
+		logWindowThreadInfo(ti.hwnd, "wintray: run thread info")
+	}
 	if ti.registerIcon() {
 		ti.SetIcon(ti.icon)
 		ti.postTestMessage()
@@ -471,9 +505,9 @@ func (ti *TrayIcon) Run(onReady, onExit func()) {
 	var msg winapi.MSG
 	log.Print("wintray: msg loop start")
 	for {
-		log.Print("wintray: before GetMessage")
+		log.Printf("wintray: before GetMessage tid=%d testPending=%t", currentThreadID(), ti.testPending)
 		r := winapi.GetMessage(&msg, 0, 0, 0)
-		log.Printf("wintray: after GetMessage r=%d msg=%d", r, msg.Message)
+		log.Printf("wintray: after GetMessage r=%d msg=%d tid=%d", r, msg.Message, currentThreadID())
 		if r == 0 {
 			log.Print("wintray: GetMessage returned 0, exiting loop")
 			ti.Dispose()
@@ -483,7 +517,7 @@ func (ti *TrayIcon) Run(onReady, onExit func()) {
 		winapi.TranslateMessage(&msg)
 		winapi.DispatchMessage(&msg)
 		if ti.testPending && time.Now().After(ti.testDeadline) {
-			log.Print("wintray: test message timeout, will re-register")
+			log.Printf("wintray: test message timeout, will re-register (deadline=%s)", ti.testDeadline.Format(time.RFC3339Nano))
 			ti.testPending = false
 			ti.reRegisterIcon()
 		}

--- a/pkg/wintray/wintray_test.go
+++ b/pkg/wintray/wintray_test.go
@@ -1,0 +1,82 @@
+package wintray
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestTrayIconCommandQueueExecutesCommands(t *testing.T) {
+	ti := NewTrayIcon()
+	var mu sync.Mutex
+	var order []int
+
+	for i := 0; i < 3; i++ {
+		idx := i
+		ti.enqueueCommand(func() {
+			mu.Lock()
+			order = append(order, idx)
+			mu.Unlock()
+		})
+	}
+
+	for i := 0; i < 3; i++ {
+		select {
+		case cmd := <-ti.commandCh:
+			if cmd.fn == nil {
+				t.Fatalf("expected command function, got nil")
+			}
+			cmd.fn()
+		default:
+			t.Fatalf("expected command #%d in queue", i)
+		}
+	}
+
+	if len(order) != 3 {
+		t.Fatalf("expected 3 executed commands, got %d", len(order))
+	}
+	for i := range order {
+		if order[i] != i {
+			t.Fatalf("expected command order %v, got %v", []int{0, 1, 2}, order)
+		}
+	}
+}
+
+func TestTrayIconCommandQueueStopsAfterShutdown(t *testing.T) {
+	ti := NewTrayIcon()
+	ti.stopCommandQueue()
+	ti.enqueueCommand(func() {
+		t.Fatalf("should not run commands after shutdown")
+	})
+
+	select {
+	case <-ti.commandCh:
+		t.Fatal("expected command queue to reject new commands after shutdown")
+	default:
+	}
+}
+
+func TestShowBalloonNotificationEnqueuesCommand(t *testing.T) {
+	ti := NewTrayIcon()
+	initial := len(ti.commandCh)
+	ti.ShowBalloonNotification("Title", "Message")
+	if len(ti.commandCh) != initial+1 {
+		t.Fatalf("expected balloon command enqueued, got queue size %d", len(ti.commandCh))
+	}
+	cmd := <-ti.commandCh
+	if cmd.fn == nil {
+		t.Fatal("expected balloon command function")
+	}
+}
+
+func TestMenuItemUpdateEnqueuesCommand(t *testing.T) {
+	ti := NewTrayIcon()
+	item := newMenuItem(ti, "Test", "Tooltip", nil)
+	item.update()
+	if len(ti.commandCh) != 1 {
+		t.Fatalf("expected menu update command enqueued, got %d", len(ti.commandCh))
+	}
+	cmd := <-ti.commandCh
+	if cmd.fn == nil {
+		t.Fatal("expected menu update command function")
+	}
+}


### PR DESCRIPTION
  - Tray UI commands were racing across goroutines and logging noise; rerouted all tray API calls through the locked-OSThread command queue so any Win32 interaction happens on the dedicated thread.
  - Removed the ad-hoc retry/re-register flow; now CreateWindowEx or Shell_NotifyIcon(NIM_ADD) failures immediately pop an error dialog and exit so the user never ends up with a headless agent plus bogus logs.
