### PR TITLE
Fix crash in message loop

### DIFF
--- a/pkg/pageant/pageant.go
+++ b/pkg/pageant/pageant.go
@@ -197,14 +197,17 @@ func (a *Pageant) RunAgent(ctx context.Context) {
 	stopWatcher := startCancelWatcher(ctx, threadID)
 	defer stopWatcher()
 
-	var msg winapi.MSG
-	for winapi.GetMessage(&msg, 0, 0, 0) != 0 {
-		winapi.TranslateMessage(&msg)
-		winapi.DispatchMessage(&msg)
+	msg := (*winapi.MSG)(unsafe.Pointer(winapi.GlobalAlloc(0, unsafe.Sizeof(winapi.MSG{}))))
+	defer winapi.GlobalFree(winapi.HGLOBAL(unsafe.Pointer(msg)))
+	for winapi.GetMessage(msg, 0, 0, 0) != 0 {
+		winapi.TranslateMessage(msg)
+		winapi.DispatchMessage(msg)
 		if msg.Message == winapi.WM_QUIT {
 			break
 		}
 	}
+
+	runtime.KeepAlive(&msg)
 }
 
 func startCancelWatcher(ctx context.Context, threadID uint32) func() {

--- a/pkg/wintray/wintray.go
+++ b/pkg/wintray/wintray.go
@@ -509,17 +509,22 @@ func (ti *TrayIcon) Run(onReady, onExit func()) {
 	//winapi.ShowWindow(ti.hwnd, winapi.SW_HIDE)
 	onReady()
 	defer onExit()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
-	var msg winapi.MSG
+	msg := (*winapi.MSG)(unsafe.Pointer(winapi.GlobalAlloc(0, unsafe.Sizeof(winapi.MSG{}))))
+	defer winapi.GlobalFree(winapi.HGLOBAL(unsafe.Pointer(msg)))
 	for {
-		r := winapi.GetMessage(&msg, 0, 0, 0)
+		r := winapi.GetMessage(msg, 0, 0, 0)
 		if r == 0 {
 			ti.Dispose()
 			break
 		}
-		winapi.TranslateMessage(&msg)
-		winapi.DispatchMessage(&msg)
+		winapi.TranslateMessage(msg)
+		winapi.DispatchMessage(msg)
 	}
+
+	runtime.KeepAlive(&msg)
 }
 
 func (ti *TrayIcon) Quit() {


### PR DESCRIPTION
GetMessage is known to crash when the Go runtime moves the goroutine stack. See https://github.com/ndbeals/winssh-pageant/issues/10.