### PR TITLE
Fix Windows CI reproducibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.go text eol=lf
+go.mod text eol=lf
+go.sum text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version-file: go.mod
           cache: true
       - name: Verify
         shell: pwsh
         run: |
-          go generate ./cmd/omnisshagent
-          if (git status --short) { throw "go generate produced changes" }
-          gofmt -w cmd internal
-          if (git status --short) { throw "gofmt produced changes" }
+          $unformatted = @(gofmt -l cmd internal)
+          if ($unformatted.Count -gt 0) {
+            $unformatted | ForEach-Object { Write-Error "gofmt required: $_" }
+            throw "gofmt check failed"
+          }
           go vet ./...
           go test ./...
           ./scripts/test-installer.ps1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,18 +15,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version-file: go.mod
           cache: true
       - name: Formatting
         shell: pwsh
         run: |
-          gofmt -w cmd internal
-          if (git status --short) { throw "gofmt produced changes" }
-      - name: Executable resources
-        shell: pwsh
-        run: |
-          go generate ./cmd/omnisshagent
-          if (git status --short) { throw "go generate produced changes" }
+          $unformatted = @(gofmt -l cmd internal)
+          if ($unformatted.Count -gt 0) {
+            $unformatted | ForEach-Object { Write-Error "gofmt required: $_" }
+            throw "gofmt check failed"
+          }
       - run: go vet ./...
       - run: go test ./...
       - name: Compile build-tagged E2E tests


### PR DESCRIPTION
## Summary

- enforce LF checkout for Go source and module files with `.gitattributes`
- make Windows and release workflows run a non-mutating `gofmt -l` check instead of rewriting the checkout and testing `git status`
- make both `actions/setup-go` steps read the required Go version from `go.mod`
- stop regenerating the checked-in Windows COFF icon resource during CI and release verification; normal builds continue to consume and validate the committed resource

## Root causes

1. The merged `main` run failed in Formatting because `gofmt -w` changed the Windows runner checkout and the workflow treated any worktree change as a formatting failure. The same source is clean with both official Go 1.25.6 and local Go 1.26.5, ruling out formatter-version drift.
2. After fixing Formatting, `go generate` rewrote the checked-in `.syso` resource to an environment-dependent byte representation on the hosted runner. Resource generation remains an explicit development step for icon changes; CI verifies the committed resource by compiling both console and `windowsgui` builds.

## Validation

- formatting check passes with Go 1.25.6 and Go 1.26.5
- `git check-attr` reports `eol: lf` for Go source, `go.mod`, and `go.sum`
- local `go test ./...`
- local `go vet ./...`
- local `git diff --check`
- hosted Windows CI passed: https://github.com/masahide/OmniSSHAgent/actions/runs/29740885113

After this merges and the `main` workflow succeeds, the planned release tag is `v0.7.0`.
