### PR TITLE
Require PowerShell for Windows migration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ automatically recovers when that agent is restarted.
 
 ## Install
 
-Open PowerShell and run:
+Open Windows PowerShell or PowerShell 7, not Command Prompt (`cmd.exe`) or Git
+Bash. Confirm that the following command returns `powershell` or `pwsh`:
+
+```powershell
+(Get-Process -Id $PID).ProcessName
+```
+
+Then run:
 
 ```powershell
 irm https://raw.githubusercontent.com/masahide/OmniSSHAgent/main/install.ps1 | iex
@@ -80,7 +87,14 @@ OmniSSHAgent does not include WSL proxy commands.
 
 ## Uninstall
 
-Run this PowerShell one-liner:
+Open Windows PowerShell or PowerShell 7, not Command Prompt (`cmd.exe`) or Git
+Bash. Confirm the current shell first:
+
+```powershell
+(Get-Process -Id $PID).ProcessName
+```
+
+It must return `powershell` or `pwsh`. Then run:
 
 ```powershell
 irm https://raw.githubusercontent.com/masahide/OmniSSHAgent/main/uninstall.ps1 | iex

--- a/docs/migration-from-legacy.md
+++ b/docs/migration-from-legacy.md
@@ -12,6 +12,33 @@ automatically.
 Read [Why OmniSSHAgent Is Being Redesigned](why-omnisshagent-is-being-redesigned.md)
 before migrating.
 
+## Use PowerShell for Windows Commands
+
+Run every Windows command in this guide from **Windows PowerShell** or
+**PowerShell 7**, not Command Prompt (`cmd.exe`) or Git Bash.
+
+Open the Start menu, type **PowerShell**, and select **Windows PowerShell** or
+**PowerShell**. The prompt normally begins with `PS`, for example:
+
+```text
+PS C:\Users\you>
+```
+
+Before continuing, run:
+
+```powershell
+(Get-Process -Id $PID).ProcessName
+$PSVersionTable.PSVersion
+```
+
+The first command must return `powershell` or `pwsh`. The second command must
+display a PowerShell version; Windows PowerShell 5.1 or later is recommended.
+If either command is reported as unrecognized, close that window and open
+PowerShell.
+
+Commands under the WSL2 sections are the exception: run fenced `bash` commands
+inside the applicable WSL2 distribution.
+
 ## Before You Begin
 
 Do not delete the legacy installation, its settings, Credential Manager


### PR DESCRIPTION
## Summary

- explicitly require Windows PowerShell or PowerShell 7 for Windows install, uninstall, and migration commands
- warn users not to run the commands from Command Prompt or Git Bash
- add `(Get-Process -Id $PID).ProcessName` as a current-shell check
- add `$PSVersionTable.PSVersion` to the migration preflight
- clarify that WSL2 `bash` commands remain an exception and run inside WSL2

## Why

PR #73 was merged before this follow-up commit reached the branch. Without an explicit shell check, users may open Command Prompt and paste PowerShell-only `irm ... | iex` commands.

## Validation

- comparison with current `main` contains only `README.md` and `docs/migration-from-legacy.md`
- `git diff --check`